### PR TITLE
Update path to hotswap-agent.properties in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ other platform/version, currently you need to compile the file yourself from the
   See [IntelliJ IDEA](https://groups.google.com/forum/#!topic/hotswapagent/BxAK_Clniss)
   and [Netbeans](https://groups.google.com/forum/#!topic/hotswapagent/ydW5bQMwQqU) forum threads for IDE specific setup guides.
 1. (optional) create a file named "hotswap-agent.properties" inside your resources directory, see available properties and
-  default values: <https://github.com/HotswapProjects/HotswapAgent/blob/master/core/src/main/resources/hotswap-agent.properties>
+  default values: <https://github.com/HotswapProjects/HotswapAgent/blob/master/hotswap-agent-core/src/main/resources/hotswap-agent.properties>
 1. start the application in debug mode, check that the agent and plugins are initialized correctly:
 
         HOTSWAP AGENT: 9:49:29.548 INFO (org.hotswap.agent.HotswapAgent) - Loading Hotswap agent - unlimited runtime class redefinition.


### PR DESCRIPTION
Currently the path to hotswap-agent.properties is pointing at an old location. 
Update it to the new location
