### PR TITLE
Move the PluginConfiguration creation off the constructor to the init…

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginManager.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginManager.java
@@ -41,10 +41,6 @@ public class PluginManager {
     private PluginManager() {
         hotswapTransformer = new HotswapTransformer();
         pluginRegistry = new PluginRegistry(this, classLoaderPatcher);
-
-        // create default configuration from this classloader
-        ClassLoader classLoader = getClass().getClassLoader();
-        classLoaderConfigurations.put(classLoader, new PluginConfiguration(classLoader));
     }
 
     // the instrumentation API
@@ -93,6 +89,11 @@ public class PluginManager {
      */
     public void init(Instrumentation instrumentation) {
         this.instrumentation = instrumentation;
+
+        // create default configuration from this classloader
+        ClassLoader classLoader = getClass().getClassLoader();
+        classLoaderConfigurations.put(classLoader, new PluginConfiguration(classLoader));
+
         if (watcher == null) {
             try {
                 watcher = new WatcherFactory().getWatcher();


### PR DESCRIPTION
… because it require the PluginManager not yet created when the pluginPackages property is used.

Before HotswapAgent was crashing with an NPE on startup.