### PR TITLE
Windows watcher service

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/WatcherFactory.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/WatcherFactory.java
@@ -1,5 +1,6 @@
 package org.hotswap.agent.watch;
 
+import org.hotswap.agent.watch.nio.TreeWatcherNIO;
 import org.hotswap.agent.watch.nio.WatcherNIO2;
 
 import java.io.IOException;
@@ -21,10 +22,20 @@ public class WatcherFactory {
         }
         return Double.parseDouble(version.substring(0, pos - 1));
     }
+    
+    public static boolean IS_WINDOWS = isWindows();
 
+    static boolean isWindows() {
+        return System.getProperty("os.name").startsWith("Windows");
+    }
+    
     public Watcher getWatcher() throws IOException {
         if (JAVA_VERSION >= 1.7) {
-            return new WatcherNIO2();
+            if (IS_WINDOWS) {
+                return new TreeWatcherNIO();
+            } else {
+                return new WatcherNIO2();
+            }
         } else {
             throw new UnsupportedOperationException("Watcher is implemented only for Java 1.7 (NIO2). " +
                     "JNotify implementation should be added in the future for older Java version support.");

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/AbstractNIO2Watcher.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/AbstractNIO2Watcher.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * This file is part of HotswapAgent.
+ * 
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.watch.nio;
+
+import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.hotswap.agent.logging.AgentLogger;
+import org.hotswap.agent.logging.AgentLogger.Level;
+import org.hotswap.agent.watch.WatchEventListener;
+import org.hotswap.agent.watch.Watcher;
+
+/**
+ * NIO2 watcher implementation for systems which support
+ * ExtendedWatchEventModifier.FILE_TREE
+ * <p/>
+ * Java 7 (NIO2) watch a directory (or tree) for changes to files.
+ * <p/>
+ * By http://docs.oracle.com/javase/tutorial/essential/io/examples/WatchDir.java
+ *
+ * @author Jiri Bubnik
+ * @author alpapad@gmail.com
+ */
+public abstract class AbstractNIO2Watcher implements Watcher {
+    protected AgentLogger LOGGER = AgentLogger.getLogger(this.getClass());
+
+    protected final static WatchEvent.Kind<?>[] KINDS = new WatchEvent.Kind<?>[] { ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY };
+
+    protected WatchService watcher;
+    protected final Map<WatchKey, PathPair> keys;
+    private final Map<Path, List<WatchEventListener>> listeners = new ConcurrentHashMap<Path, List<WatchEventListener>>();
+
+    // keep track about which classloader requested which event
+    protected Map<WatchEventListener, ClassLoader> classLoaderListeners = new ConcurrentHashMap<WatchEventListener, ClassLoader>();
+
+    private Thread runner;
+
+    private volatile boolean stopped;
+
+    protected final EventDispatcher dispatcher;
+
+    public AbstractNIO2Watcher() throws IOException {
+        this.watcher = FileSystems.getDefault().newWatchService();
+        this.keys = new ConcurrentHashMap<WatchKey, PathPair>();
+        dispatcher = new EventDispatcher(listeners);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> WatchEvent<T> cast(WatchEvent<?> event) {
+        return (WatchEvent<T>) event;
+    }
+
+    @Override
+    public synchronized void addEventListener(ClassLoader classLoader, URI pathPrefix, WatchEventListener listener) {
+        File path;
+        try {
+            // check that it is regular file
+            // toString() is weird and solves HiarchicalUriException for URI
+            // like "file:./src/resources/file.txt".
+            path = new File(pathPrefix);
+         } catch (IllegalArgumentException e) {
+            if (!LOGGER.isLevelEnabled(Level.TRACE)) {
+                LOGGER.warning("Unable to watch for path {}, not a local regular file or directory.", pathPrefix);
+            } else {
+                LOGGER.trace("Unable to watch for path {} exception", e, pathPrefix);
+            }
+            return;
+        }
+
+        try {
+            addDirectory(path.toPath());
+        } catch (IOException e) {
+            if (!LOGGER.isLevelEnabled(Level.TRACE)) {
+                LOGGER.warning("Unable to watch for path {}, not a local regular file or directory.", pathPrefix);
+            } else {
+                LOGGER.trace("Unable to watch path with prefix '{}' for changes.", e, pathPrefix);
+            }
+            return;
+        }
+
+        List<WatchEventListener> list = listeners.get(Paths.get(pathPrefix));
+        if (list == null) {
+            list = new ArrayList<WatchEventListener>();
+            listeners.put(Paths.get(pathPrefix), list);
+        }
+        list.add(listener);
+
+        if (classLoader != null) {
+            classLoaderListeners.put(listener, classLoader);
+        }
+    }
+
+    @Override
+    public void addEventListener(ClassLoader classLoader, URL pathPrefix, WatchEventListener listener) {
+        if (pathPrefix == null) {
+            return;
+        }
+
+        try {
+            addEventListener(classLoader, pathPrefix.toURI(), listener);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Unable to convert URL to URI " + pathPrefix, e);
+        }
+    }
+
+    /**
+     * Remove all transformers registered with a classloader
+     * 
+     * @param classLoader
+     */
+    @Override
+    public void closeClassLoader(ClassLoader classLoader) {
+        for (Iterator<Entry<WatchEventListener, ClassLoader>> entryIterator = classLoaderListeners.entrySet().iterator(); entryIterator.hasNext();) {
+            Entry<WatchEventListener, ClassLoader> entry = entryIterator.next();
+            if (entry.getValue().equals(classLoader)) {
+                entryIterator.remove();
+                try {
+                    for (Iterator<Entry<Path, List<WatchEventListener>>> listenersIterator = listeners.entrySet().iterator(); listenersIterator.hasNext();) {
+                        Entry<Path, List<WatchEventListener>> pathListenerEntry = listenersIterator.next();
+                        List<WatchEventListener> l = pathListenerEntry.getValue();
+
+                        if (l != null) {
+                            l.remove(entry.getKey());
+                        }
+
+                        if (l == null || l.isEmpty()) {
+                            listenersIterator.remove();
+                        }
+
+                    }
+                } catch (Exception e) {
+                    LOGGER.error("Ooops", e);
+                }
+            }
+        }
+        // cleanup...
+        if (classLoaderListeners.isEmpty()) {
+            listeners.clear();
+            for (WatchKey wk : keys.keySet()) {
+                try {
+                    wk.cancel();
+                } catch (Exception e) {
+                    LOGGER.error("Ooops", e);
+                }
+            }
+            try {
+                this.watcher.close();
+            } catch (IOException e) {
+                LOGGER.error("Ooops", e);
+            }
+            LOGGER.info("All classloaders closed, released watch service..");
+            try {
+                // Reset
+                this.watcher = FileSystems.getDefault().newWatchService();
+            } catch (IOException e) {
+                LOGGER.error("Ooops", e);
+            }
+        }
+        LOGGER.debug("All watch listeners removed for classLoader {}", classLoader);
+    }
+
+    /**
+     * Registers the given directory
+     */
+    public void addDirectory(Path path) throws IOException {
+       registerAll(null, path);
+    }
+
+    protected abstract void registerAll(final Path watched, final Path target) throws IOException;
+
+    /**
+     * Process all events for keys queued to the watcher
+     *
+     * @return true if should continue
+     * @throws InterruptedException
+     */
+    private boolean processEvents() throws InterruptedException {
+
+        // wait for key to be signalled
+        WatchKey key = watcher.poll(10, TimeUnit.MILLISECONDS);
+        if (key == null) {
+            return true;
+        }
+
+        PathPair dir = keys.get(key);
+
+        if (dir == null) {
+            LOGGER.warning("WatchKey '{}' not recognized", key);
+            return true;
+        }
+
+        for (WatchEvent<?> event : key.pollEvents()) {
+            WatchEvent.Kind<?> kind = event.kind();
+
+            if (kind == OVERFLOW) {
+                LOGGER.warning("WatchKey '{}' overflowed", key);
+                continue;
+            }
+
+            // Context for directory entry event is the file name of entry
+            WatchEvent<Path> ev = cast(event);
+            Path name = ev.context();
+            Path child = dir.resolve(name);
+
+            LOGGER.debug("Watch event '{}' on '{}' --> {}", event.kind().name(), child, name);
+
+            dispatcher.add(ev, child);
+
+            // if directory is created, and watching recursively, then
+            // register it and its sub-directories
+            if (kind == ENTRY_CREATE) {
+                try {
+                    if (Files.isDirectory(child, NOFOLLOW_LINKS)) {
+                        registerAll(dir.getWatched(), child);
+                    }
+                } catch (IOException x) {
+                    LOGGER.warning("Unable to register events for directory {}", x, child);
+                }
+            }
+        }
+
+        // reset key and remove from set if directory no longer accessible
+        boolean valid = key.reset();
+        if (!valid) {
+            LOGGER.warning("Watcher on {} not valid, removing...", keys.get(key));
+            keys.remove(key);
+            // all directories are inaccessible
+            if (keys.isEmpty()) {
+                return false;
+            }
+            if (classLoaderListeners.isEmpty()) {
+                for (WatchKey k : keys.keySet()) {
+                    k.cancel();
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void run() {
+
+        runner = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    for (;;) {
+                        if (stopped || !processEvents()) {
+                            break;
+                        }
+                    }
+                } catch (InterruptedException x) {
+
+                }
+            }
+        };
+        runner.setDaemon(true);
+        runner.setName("HotSwap Watcher");
+        runner.start();
+
+        dispatcher.start();
+    }
+
+    @Override
+    public void stop() {
+        stopped = true;
+    }
+
+    /**
+     * Get a Watch event modifier. These are platform specific and hiden in sun api's
+     *
+     * @see <a href="https://github.com/HotswapProjects/HotswapAgent/issues/41">
+     *      Issue#41</a>
+     * @see <a href=
+     *      "http://stackoverflow.com/questions/9588737/is-java-7-watchservice-slow-for-anyone-else">
+     *      Is Java 7 WatchService Slow for Anyone Else?</a>
+     */
+    static WatchEvent.Modifier getWatchEventModifier(String claz, String field) {
+        try {
+            Class<?> c = Class.forName(claz);
+            Field f = c.getField(field);
+            return (WatchEvent.Modifier) f.get(c);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/EventDispatcher.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/EventDispatcher.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * This file is part of HotswapAgent.
+ * 
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.watch.nio;
+
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.hotswap.agent.logging.AgentLogger;
+import org.hotswap.agent.watch.WatchEventListener;
+import org.hotswap.agent.watch.WatchFileEvent;
+
+/**
+ * The EventDispatcher holds a queue of all events collected by the watcher but
+ * not yet processed. It runs on its own thread and is responsible for calling
+ * all the registered listeners.
+ * 
+ * Since file system events can spawn too fast, this implementation works as
+ * buffer for fast spawning events. The watcher is now responsible for
+ * collecting and pushing events in this queue.
+ * 
+ */
+public class EventDispatcher implements Runnable {
+
+    /** The logger. */
+    protected AgentLogger LOGGER = AgentLogger.getLogger(this.getClass());
+
+    /**
+     * The Class Event.
+     */
+    static class Event {
+
+        /** The event. */
+        final WatchEvent<Path> event;
+
+        /** The path. */
+        final Path path;
+
+        /**
+         * Instantiates a new event.
+         *
+         * @param event
+         *            the event
+         * @param path
+         *            the path
+         */
+        public Event(WatchEvent<Path> event, Path path) {
+            super();
+            this.event = event;
+            this.path = path;
+        }
+    }
+
+    /** The map of listeners.  This is managed by the watcher service*/
+    private final Map<Path, List<WatchEventListener>> listeners;
+
+    /** The working queue. The event queue is drained and all pending events are added in this list */
+    private final ArrayList<Event> working = new ArrayList<>();
+
+    /** The runnable. */
+    private Thread runnable = null;
+
+    /**
+     * Instantiates a new event dispatcher.
+     *
+     * @param listeners
+     *            the listeners
+     */
+    public EventDispatcher(Map<Path, List<WatchEventListener>> listeners) {
+        super();
+        this.listeners = listeners;
+    }
+
+    /** The event queue. */
+    private final ArrayBlockingQueue<Event> eventQueue = new ArrayBlockingQueue<>(500);
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Runnable#run()
+     */
+    @Override
+    public void run() {
+
+        /*
+         * The algorithm is naive: 
+         * a) work with not processed (in case);
+         * b) drain the queue
+         * c) work on newly collected
+         * d) empty working queue
+         */
+        while (true) {
+            // finish any pending ones
+            for (Event e : working) {
+                callListeners(e.event, e.path);
+                if (Thread.interrupted()) {
+                    return;
+                }
+                Thread.yield();
+            }
+            // drain the event queue
+            eventQueue.drainTo(working);
+
+            // work on new events.
+            for (Event e : working) {
+                callListeners(e.event, e.path);
+                if (Thread.interrupted()) {
+                    return;
+                }
+                Thread.yield();
+            }
+
+            // crear the working queue.
+            working.clear();
+
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e1) {
+                // TODO Auto-generated catch block
+                return;
+            }
+        }
+    }
+
+    /**
+     * Adds the.
+     *
+     * @param event
+     *            the event
+     * @param path
+     *            the path
+     */
+    public void add(WatchEvent<Path> event, Path path) {
+        eventQueue.offer(new Event(event, path));
+    }
+
+    /**
+     * Call the listeners.
+     * Listeners are organized per path in a Map. The number of paths is low so a simple iteration should be fast enough. 
+     *  
+     * @param event
+     *            the event
+     * @param path
+     *            the path
+     */
+    // notify listeners about new event
+    private void callListeners(final WatchEvent<?> event, final Path path) {
+        boolean matchedOne = false;
+        for (Map.Entry<Path, List<WatchEventListener>> list : listeners.entrySet()) {
+            if (path.startsWith(list.getKey())) {
+                matchedOne = true;
+                for (WatchEventListener listener : list.getValue()) {
+                    WatchFileEvent agentEvent = new HotswapWatchFileEvent(event, path);
+                    try {
+                        listener.onEvent(agentEvent);
+                    } catch (Throwable e) {
+                        // LOGGER.error("Error in watch event '{}' listener
+                        // '{}'", e, agentEvent, listener);
+                    }
+                }
+            }
+        }
+        if (!matchedOne) {
+            LOGGER.error("No match for  watch event '{}',  path '{}'", event, path);
+        }
+    }
+
+    /**
+     * Start.
+     */
+    public void start() {
+        runnable = new Thread(this);
+        runnable.setDaemon(true);
+        runnable.setName("HotSwap Dispatcher");
+        runnable.start();
+    }
+
+    /**
+     * Stop.
+     *
+     * @throws InterruptedException
+     *             the interrupted exception
+     */
+    public void stop() throws InterruptedException {
+        if (runnable != null) {
+            runnable.interrupt();
+            runnable.join();
+        }
+        runnable = null;
+    }
+}

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/HotswapWatchFileEvent.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/HotswapWatchFileEvent.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * This file is part of HotswapAgent.
+ * 
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.watch.nio;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+
+import java.net.URI;
+import java.nio.file.Files;
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * This file is part of HotswapAgent.
+ * 
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+
+import org.hotswap.agent.annotation.FileEvent;
+import org.hotswap.agent.watch.WatchFileEvent;
+
+/**
+ * Filesystem event.
+ */
+public class HotswapWatchFileEvent implements WatchFileEvent {
+
+	private final WatchEvent<?> event;
+	private final Path path;
+
+	public HotswapWatchFileEvent(WatchEvent<?> event, Path path) {
+		this.event = event;
+		this.path = path;
+	}
+
+	@Override
+	public FileEvent getEventType() {
+		return toAgentEvent(event.kind());
+	}
+
+	@Override
+	public URI getURI() {
+		return path.toUri();
+	}
+
+	@Override
+	public boolean isFile() {
+		// return Files.isRegularFile(path); - did not work in some cases
+		return !isDirectory();
+	}
+
+	@Override
+	public boolean isDirectory() {
+		return Files.isDirectory(path);
+	}
+
+	@Override
+	public String toString() {
+		return "WatchFileEvent on path " + path + " for event " + event.kind();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		HotswapWatchFileEvent that = (HotswapWatchFileEvent) o;
+
+		if (!event.equals(that.event)) {
+			return false;
+		}
+		if (!path.equals(that.path)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = event.hashCode();
+		result = 31 * result + path.hashCode();
+		return result;
+	}
+	
+	
+
+	// translate constants between NIO event and ageent event
+	static FileEvent toAgentEvent(WatchEvent.Kind<?> kind) {
+		if (kind == ENTRY_CREATE) {
+			return FileEvent.CREATE;
+		} else if (kind == ENTRY_MODIFY) {
+			return FileEvent.MODIFY;
+		} else if (kind == ENTRY_DELETE) {
+			return FileEvent.DELETE;
+		} else {
+			throw new IllegalArgumentException("Unknown event type " + kind.name());
+		}
+	}
+}

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/PathPair.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/PathPair.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * This file is part of HotswapAgent.
+ * 
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.watch.nio;
+
+import java.nio.file.Path;
+
+/**
+ * <p>
+ * The PathPair is used for the windows watcher implementation. In ntfs the
+ * watched directories are locked so deleting them is impossible. The windows
+ * watcher watches one directory down ( at the expense of getting many more
+ * events) and this class holds the mapping between the <code>target</code>
+ * directory (the one we intend to listen events) vs the actually
+ * <code>watched</code> directory.
+ * </p>
+ * <p>
+ * This workaround, does not completely eliminate the locking problem. For
+ * example, when working with maven projects one first needs to clean and then
+ * build (two commands).
+ * 
+ * In eclipse, sometimes the m2e plugin complains that it can not access
+ * generated files. This is usually fixed with a clean.
+ * </p>
+ * 
+ * @author alpapad@gmail.com
+ */
+public class PathPair {
+
+    /** The target path. */
+    private final Path target;
+
+    /** The watched path. */
+    private final Path watched;
+
+    /**
+     * Factory method for creating target-target path pair
+     *
+     * @param target
+     * @return the path pair
+     */
+    public static PathPair get(Path target) {
+        return new PathPair(target);
+    }
+
+    /**
+     * Factory method for creating a target-watched path pair
+     *
+     * @param target the target path
+     * @param watched the watched path
+     * @return the path pair
+     */
+    public static PathPair get(Path target, Path watched) {
+        return new PathPair(target, watched);
+    }
+
+    /**
+     * Instantiates a new path pair.
+     *
+     * @param target
+     *            the target
+     */
+    public PathPair(Path target) {
+        this(target, target);
+    }
+
+    /**
+     * Instantiates a new path pair.
+     *
+     * @param target  the target path
+     * @param watched the watched path
+     */
+    public PathPair(Path target, Path watched) {
+        this.target = target;
+        this.watched = watched;
+    }
+
+    /**
+     * Gets the watched path.
+     *
+     * @return the watched path
+     */
+    public Path getWatched() {
+        return watched;
+    }
+
+    /**
+     * Gets the target path
+     *
+     * @return the target path
+     */
+    public Path getTarget() {
+        return target;
+    }
+
+    /**
+     * Resolve a relative path (as returned by the java watcher) to an absolute path
+     *
+     * @param other
+     *            the other
+     * @return the path
+     */
+    public Path resolve(Path other) {
+        return watched.resolve(other);
+    }
+
+    /**
+     * Checks if the parameter path is being watched.
+     *
+     * @param target
+     *            the target
+     * @return true, if is watching
+     */
+    public boolean isWatching(Path target) {
+        return target.startsWith(watched);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (watched == null ? 0 : watched.hashCode());
+        return result;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        PathPair other = (PathPair) obj;
+        if (watched == null) {
+            if (other.watched != null) {
+                return false;
+            }
+        } else if (!watched.equals(other.watched)) {
+            return false;
+        }
+        return true;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "PathPair [target=" + target + ", watched=" + watched + "]";
+    }
+}

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/TreeWatcherNIO.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/TreeWatcherNIO.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * This file is part of HotswapAgent.
+ * 
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.watch.nio;
+
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+
+/**
+ * <p>
+ * NIO2 watcher implementation for systems which support
+ * ExtendedWatchEventModifier.FILE_TREE (windows)
+ * </p>
+ * <p>
+ * Java 7 (NIO2) watch a directory (or tree) for changes to files.
+ * </p>
+ *
+ * @author alpapad@gmail.com
+ */
+public class TreeWatcherNIO extends AbstractNIO2Watcher {
+
+    
+    private final static WatchEvent.Modifier HIGH;
+    private final static WatchEvent.Modifier FILE_TREE;
+    private final static WatchEvent.Modifier[] MODIFIERS;
+    
+    static {
+        // try to set high sensitivity
+        HIGH =  getWatchEventModifier("com.sun.nio.file.SensitivityWatchEventModifier","HIGH"); 
+        // try to set file tree modifier
+        FILE_TREE = getWatchEventModifier("com.sun.nio.file.ExtendedWatchEventModifier", "FILE_TREE");
+        
+        if(FILE_TREE != null) {
+            MODIFIERS =  new WatchEvent.Modifier[] { FILE_TREE, HIGH };
+        } else {
+            MODIFIERS =  new WatchEvent.Modifier[] { HIGH };
+        }
+    }
+    /**
+	 * Instantiates a new tree watcher nio.
+	 *
+	 * @throws IOException Signals that an I/O exception has occurred.
+	 */
+	public TreeWatcherNIO() throws IOException {
+		super();
+	}
+
+	/**
+	 * Register the given directory with the WatchService.
+	 *
+	 * @param watched the watched path
+	 * @param target the target path (could be different than watched)
+	 * @throws IOException Signals that an I/O exception has occurred.
+	 */
+	private void register(Path watched, Path target) throws IOException {
+		
+		for(PathPair p: keys.values()) {
+			// This may NOT be correct for all cases (ensure resolve will work!)
+			if(p.isWatching(target)) {
+				LOGGER.debug("Path {} watched via {}", target, p.getWatched());
+				return;
+			}
+		}
+	
+		if (FILE_TREE == null) {
+			LOGGER.debug("WATCHING:ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY - high} {}", watched);
+		} else {
+			LOGGER.debug("WATCHING: ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY - fileTree,high {}", watched);
+		}
+		
+		final WatchKey key = watched.register(watcher, KINDS,  MODIFIERS);
+		
+		keys.put(key, new PathPair(target, watched));
+	}
+
+	/**
+	 * Register the given directory,  with the
+	 * WatchService. Sub-directories are automatically watched (filesystem supported)
+	 *
+	 * @param watched the watched
+	 * @param target the target
+	 * @throws IOException Signals that an I/O exception has occurred.
+	 */
+	protected void registerAll(Path watched, Path target) throws IOException {
+		if(watched == null){
+			watched = target.getParent();
+		}
+		LOGGER.info("Registering directory target {} via watched: {}", target, watched);
+		
+		register(watched, target);
+	}
+}

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/WatcherNIO2.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/WatcherNIO2.java
@@ -1,24 +1,31 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * This file is part of HotswapAgent.
+ * 
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
 package org.hotswap.agent.watch.nio;
 
-
-import org.hotswap.agent.annotation.FileEvent;
-import org.hotswap.agent.logging.AgentLogger;
-import org.hotswap.agent.watch.WatchFileEvent;
-import org.hotswap.agent.watch.WatchEventListener;
-import org.hotswap.agent.watch.Watcher;
-
-import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.*;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.*;
-
-import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
-import static java.nio.file.StandardWatchEventKinds.*;
 
 /**
  * NIO2 watcher implementation.
@@ -28,335 +35,45 @@ import static java.nio.file.StandardWatchEventKinds.*;
  * By http://docs.oracle.com/javase/tutorial/essential/io/examples/WatchDir.java
  *
  * @author Jiri Bubnik
+ * @author alpapad@gmail.com
  */
-public class WatcherNIO2 implements Watcher {
-    private static AgentLogger LOGGER = AgentLogger.getLogger(WatcherNIO2.class);
-
-    private final WatchService watcher;
-    private final Map<WatchKey, Path> keys;
-    private final Map<Path, List<WatchEventListener>> listeners = new HashMap<Path, List<WatchEventListener>>();
-
-    // keep track about which classloader requested which event
-    protected Map<WatchEventListener, ClassLoader> classLoaderListeners = new HashMap<WatchEventListener, ClassLoader>();
-
-
-    Thread runner;
-    boolean stopped;
-
-    public WatcherNIO2() throws IOException {
-        this.watcher = FileSystems.getDefault().newWatchService();
-        this.keys = new HashMap<WatchKey, Path>();
+public class WatcherNIO2 extends AbstractNIO2Watcher {
+    private final static WatchEvent.Modifier HIGH;
+    
+    static {
+        HIGH =  getWatchEventModifier("com.sun.nio.file.SensitivityWatchEventModifier","HIGH"); 
     }
-
-    @SuppressWarnings("unchecked")
-    static <T> WatchEvent<T> cast(WatchEvent<?> event) {
-        return (WatchEvent<T>) event;
-    }
-
-    @Override
-    public synchronized void addEventListener(ClassLoader classLoader, URI pathPrefix, WatchEventListener listener) {
-        File path;
-        try {
-            // check that it is regular file
-            // toString() is weird and solves HiarchicalUriException for URI like "file:./src/resources/file.txt".
-            path = new File(pathPrefix);
-        } catch (IllegalArgumentException e) {
-            LOGGER.warning("Unable to watch for path {}, not a local regular file or directory.", pathPrefix);
-            LOGGER.trace("Unable to watch for path {} exception", e, pathPrefix);
-            return;
-        }
-
-        try {
-            addDirectory(path.toURI());
-        } catch (IOException e) {
-            LOGGER.error("Unable to watch path with prefix '{}' for changes.", e, pathPrefix);
-            return;
-        }
-
-        List<WatchEventListener> list = listeners.get(Paths.get(pathPrefix));
-        if (list == null) {
-            list = new ArrayList<WatchEventListener>();
-            listeners.put(Paths.get(pathPrefix), list);
-        }
-        list.add(listener);
-
-        if (classLoader != null)
-            classLoaderListeners.put(listener, classLoader);
-    }
-
-    @Override
-    public void addEventListener(ClassLoader classLoader, URL pathPrefix, WatchEventListener listener) {
-        try {
-            addEventListener(classLoader, pathPrefix.toURI(), listener);
-        } catch (URISyntaxException e) {
-            throw new RuntimeException("Unable to convert URL to URI " + pathPrefix, e);
-        }
-    }
-
-    /**
-     * Remove all transformers registered with a classloader
-     * @param classLoader
-     */
-    public void closeClassLoader(ClassLoader classLoader) {
-        for (Iterator<Map.Entry<WatchEventListener, ClassLoader>> entryIterator = classLoaderListeners.entrySet().iterator();
-             entryIterator.hasNext(); ) {
-            Map.Entry<WatchEventListener, ClassLoader> entry = entryIterator.next();
-            if (entry.getValue().equals(classLoader)) {
-                entryIterator.remove();
-                for (List<WatchEventListener> transformerList : listeners.values())
-                    transformerList.remove(entry.getKey());
-            }
-        }
-
-        LOGGER.debug("All watch listeners removed for classLoader {}", classLoader);
-    }
-
-    /**
-     * Registers the given directory
-     */
-    public void addDirectory(URI path) throws IOException {
-        try {
-            Path dir = Paths.get(path);
-
-            if (keys.values().contains(dir))
-                return;
-
-            registerAll(dir);
-        } catch (IllegalArgumentException e) {
-            throw new IOException("Invalid URI format " + path, e);
-        } catch (FileSystemNotFoundException e) {
-            throw new IOException("Invalid URI " + path, e);
-        } catch (SecurityException e) {
-            throw new IOException("Security exception for URI " + path, e);
-        }
-    }
+    
+	public WatcherNIO2() throws IOException {
+		super();
+	}
 
 
-    /**
-     * Register the given directory with the WatchService
-     */
-    private void register(Path dir) throws IOException {
-        // check duplicate registration
-        if (keys.values().contains(dir))
-            return;
+	/**
+	 * Register the given directory, and all its sub-directories, with the
+	 * WatchService.
+	 */
+	@Override
+	protected void registerAll(final Path parent, Path start) throws IOException {
+		// register directory and sub-directories
+		LOGGER.info("Registering directory  {} under parent {}", start, parent);
 
-        // try to set high sensitivity
-        WatchEvent.Modifier high = get_com_sun_nio_file_SensitivityWatchEventModifier_HIGH();
-        WatchKey key =
-                (high == null) ?
-                        dir.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY) :
-                        dir.register(watcher, new WatchEvent.Kind<?>[]{ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY}, high);
+		Files.walkFileTree(start, new SimpleFileVisitor<Path>() {
+			@Override
+			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+				register(dir);
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
 
-        keys.put(key, dir);
-    }
-
-    /**
-     * Register the given directory, and all its sub-directories, with the
-     * WatchService.
-     */
-    private void registerAll(final Path start) throws IOException {
-        // register directory and sub-directories
-        Files.walkFileTree(start, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
-                    throws IOException {
-                register(dir);
-                return FileVisitResult.CONTINUE;
-            }
-        });
-    }
-
-
-    /**
-     * Process all events for keys queued to the watcher
-     *
-     * @return true if should continue
-     */
-    private boolean processEvents() {
-
-        // wait for key to be signalled
-        WatchKey key;
-        try {
-            key = watcher.take();
-        } catch (InterruptedException x) {
-            return false;
-        }
-
-
-        Path dir = keys.get(key);
-        if (dir == null) {
-            LOGGER.warning("WatchKey '{}' not recognized", key);
-            return true;
-        }
-
-        for (WatchEvent<?> event : key.pollEvents()) {
-            WatchEvent.Kind kind = event.kind();
-
-            if (kind == OVERFLOW) {
-                LOGGER.warning("WatchKey '{}' overflowed", key);
-                continue;
-            }
-
-            // Context for directory entry event is the file name of entry
-            WatchEvent<Path> ev = cast(event);
-            Path name = ev.context();
-            Path child = dir.resolve(name);
-
-            LOGGER.trace("Watch event '{}' on '{}'", event.kind().name(), child);
-
-            callListeners(event, child);
-
-            // if directory is created, and watching recursively, then
-            // register it and its sub-directories
-            if (kind == ENTRY_CREATE) {
-                try {
-                    if (Files.isDirectory(child, NOFOLLOW_LINKS)) {
-                        registerAll(child);
-                    }
-                } catch (IOException x) {
-                    LOGGER.warning("Unable to register events for directory {}", x, child);
-                }
-            }
-        }
-
-        // reset key and remove from set if directory no longer accessible
-        boolean valid = key.reset();
-        if (!valid) {
-            keys.remove(key);
-
-            // all directories are inaccessible
-            if (keys.isEmpty()) {
-                return false;
-            }
-        }
-
-        return true;
-
-    }
-
-    // notify listeners about new event
-    private void callListeners(final WatchEvent event, final Path path) {
-        for (Map.Entry<Path, List<WatchEventListener>> list : listeners.entrySet()) {
-            for (WatchEventListener listener : list.getValue()) {
-                if (path.startsWith(list.getKey())) {
-                    WatchFileEvent agentEvent = new HotswapWatchFileEvent(event, path);
-
-                    try {
-                        listener.onEvent(agentEvent);
-                    } catch (Throwable e) {
-                        LOGGER.error("Error in watch event '{}' listener '{}'", e, agentEvent, listener);
-                    }
-                }
-            }
-        }
-    }
-
-    // translate constants between NIO event and ageent event
-    private static FileEvent toAgentEvent(WatchEvent.Kind kind) {
-        if (kind == ENTRY_CREATE)
-            return FileEvent.CREATE;
-        else if (kind == ENTRY_MODIFY)
-            return FileEvent.MODIFY;
-        else if (kind == ENTRY_DELETE)
-            return FileEvent.DELETE;
-        else
-            throw new IllegalArgumentException("Unknown event type " + kind.name());
-    }
-
-    @Override
-    public void run() {
-        runner = new Thread() {
-            @Override
-            public void run() {
-                for (; ; ) {
-                    if (stopped || !processEvents())
-                        break;
-                }
-            }
-        };
-
-        runner.setDaemon(true);
-        runner.start();
-    }
-
-    @Override
-    public void stop() {
-        stopped = true;
-    }
-
-    /**
-     * Filesystem event.
-     */
-    public static class HotswapWatchFileEvent implements WatchFileEvent {
-
-        private final WatchEvent event;
-        private final Path path;
-
-        public HotswapWatchFileEvent(WatchEvent event, Path path) {
-            this.event = event;
-            this.path = path;
-        }
-
-        @Override
-        public FileEvent getEventType() {
-            return toAgentEvent(event.kind());
-        }
-
-        @Override
-        public URI getURI() {
-            return path.toUri();
-        }
-
-        @Override
-        public boolean isFile() {
-            //return Files.isRegularFile(path); - did not work in some cases
-            return !isDirectory();
-        }
-
-        @Override
-        public boolean isDirectory() {
-            return Files.isDirectory(path);
-        }
-
-        @Override
-        public String toString() {
-            return "WatchFileEvent on path " + path + " for event " + event.kind();
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            HotswapWatchFileEvent that = (HotswapWatchFileEvent) o;
-
-            if (!event.equals(that.event)) return false;
-            if (!path.equals(that.path)) return false;
-
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            int result = event.hashCode();
-            result = 31 * result + path.hashCode();
-            return result;
-        }
-    }
-
-    /**
-     * Get modifier for high sensitivity on Watch events.
-     *
-     * @see <a href="https://github.com/HotswapProjects/HotswapAgent/issues/41">Issue#41</a>
-     * @see <a href="http://stackoverflow.com/questions/9588737/is-java-7-watchservice-slow-for-anyone-else">Is Java 7 WatchService Slow for Anyone Else?</a>
-     */
-    WatchEvent.Modifier get_com_sun_nio_file_SensitivityWatchEventModifier_HIGH() {
-        try {
-            Class<?> c = Class.forName("com.sun.nio.file.SensitivityWatchEventModifier");
-            Field f = c.getField("HIGH");
-            return (WatchEvent.Modifier) f.get(c);
-        } catch (Exception e) {
-            return null;
-        }
-    }
+	/**
+	 * Register the given directory with the WatchService
+	 */
+	private void register(Path dir) throws IOException {
+		// try to set high sensitivity
+		final WatchKey key = HIGH == null ? dir.register(watcher, KINDS) : dir.register(watcher, KINDS, HIGH);
+		
+		keys.put(key, PathPair.get(dir));
+	}
 }


### PR DESCRIPTION
Refactored watcher service so a different implementation is used in
unices and windows. In windows the FILE_TREE modifier is used and sub directories are watched by the service (no need to register each directory individually)