### PR TITLE
Support additional plugin packages via config option

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/HotswapAgent.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/HotswapAgent.java
@@ -6,7 +6,10 @@ import org.hotswap.agent.config.PluginManager;
 import org.hotswap.agent.util.Version;
 
 import java.lang.instrument.Instrumentation;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -30,6 +33,11 @@ public class HotswapAgent {
     private static Set<String> disabledPlugins = new HashSet<String>();
 
     /**
+     * Additional packages to be scanned for plugins.
+     */
+    private static String[] otherPluginPackages = new String[] {};
+
+    /**
      * Default value for autoHotswap property.
      */
     private static boolean autoHotswap = false;
@@ -44,7 +52,7 @@ public class HotswapAgent {
         LOGGER.info("Loading Hotswap agent {{}} - unlimited runtime class redefinition.", Version.version());
         parseArgs(args);
         fixJboss7Modules();
-        PluginManager.getInstance().init(inst);
+        PluginManager.getInstance().init(inst, otherPluginPackages);
         LOGGER.debug("Hotswap agent inicialized.");
 
     }
@@ -68,6 +76,8 @@ public class HotswapAgent {
                 autoHotswap = Boolean.valueOf(optionValue);
             } else if ("propertiesFilePath".equals(option)) {
                 propertiesFilePath = optionValue;
+            } else if ("otherPluginPackages".equals(option)) {
+            	otherPluginPackages = optionValue.split(";");
             } else {
                 LOGGER.warning("Invalid javaagent option '{}'. Argument '{}' is ignored.", option, arg);
             }
@@ -103,7 +113,7 @@ public class HotswapAgent {
 
     /**
      * JBoss 7 use OSGI classloading and hence agent core classes are not available from application classloader
-     * (this is not the case with standard classloaders with parent delgation).
+     * (this is not the case with standard classloaders with parent delegation).
      *
      * Wee need to simulate command line attribute -Djboss.modules.system.pkgs=org.hotswap.agent to allow any
      * classloader to access agent libraries (OSGI default export). This method does it on behalf of the user.

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginConfiguration.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginConfiguration.java
@@ -154,9 +154,7 @@ public class PluginConfiguration {
         if (properties.containsKey("pluginPackages")) {
             String pluginPackages = properties.getProperty("pluginPackages");
 
-            for (String pluginPackage : pluginPackages.split(",")) {
-                PluginManager.getInstance().getPluginRegistry().scanPlugins(getClassLoader(), pluginPackage);
-            }
+            PluginManager.getInstance().getPluginRegistry().scanPlugins(getClassLoader(), Arrays.asList(pluginPackages.split(",")));
         }
     }
 

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginManager.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginManager.java
@@ -93,13 +93,13 @@ public class PluginManager {
      * <ul>
      * <li>Create new resource watcher using WatcherFactory and start it in separate thread.</li>
      * <li>Create new scheduler and start it in separate thread.</li>
-     * <li>Scan for plugins</li>
+     * <li>Scan for plugins in the {@link #PLUGIN_PACKAGE} package first and then those specified with the {@code otherPluginPackages} argument</li>
      * <li>Register HotswapTransformer with the javaagent instrumentation class</li>
      * </ul>
      *
      * @param instrumentation javaagent instrumentation.
      */
-    public void init(Instrumentation instrumentation) {
+    public void init(Instrumentation instrumentation, String ... otherPluginPackages) {
         this.instrumentation = instrumentation;
 
         // create default configuration from this classloader
@@ -120,7 +120,10 @@ public class PluginManager {
         }
         scheduler.run();
 
-        pluginRegistry.scanPlugins(getClass().getClassLoader(), PLUGIN_PACKAGE);
+        List<String> pluginPackages = new ArrayList<String>(otherPluginPackages.length + 1);
+        pluginPackages.add(0, PLUGIN_PACKAGE);
+        pluginPackages.addAll(Arrays.asList(otherPluginPackages));
+        pluginRegistry.scanPlugins(getClass().getClassLoader(), pluginPackages);
 
         LOGGER.debug("Registering transformer ");
         instrumentation.addTransformer(hotswapTransformer);


### PR DESCRIPTION
Add support for additional packages to be scanned for plugins beside the
"org.hotswap.agent.plugin" via the additional "otherPluginPackages"
option. The additional packages are passed separated by a semicolon,
e.g., "my.happy.plugins;some.other.plugins".

Also fix some generics-related warnings.