### PR TITLE
Clear validation cache on every reload

### DIFF
--- a/plugin/hotswap-agent-webobjects-plugin/src/main/java/org/hotswap/agent/plugin/webobjects/HotswapWebObjectsPlugin.java
+++ b/plugin/hotswap-agent-webobjects-plugin/src/main/java/org/hotswap/agent/plugin/webobjects/HotswapWebObjectsPlugin.java
@@ -99,6 +99,7 @@ public class HotswapWebObjectsPlugin {
         LOGGER.debug("Class "+ctClass.getSimpleName()+" redefined.");
 
         scheduler.scheduleCommand(clearKVCCacheCommand);
+        scheduler.scheduleCommand(clearValidationCacheCommand);
 
         woApplication_removeComponentDefinitionCacheContents.invoke(woApplicationObject);
         if (ctClass.subclassOf(woComponentCtClass)) {
@@ -106,9 +107,6 @@ public class HotswapWebObjectsPlugin {
         }
         if (ctClass.subclassOf(woActionCtClass)) {
             scheduler.scheduleCommand(clearActionCacheCommand);
-        }
-        if (ctClass.subclassOf(nsValidationCtClass)) {
-            scheduler.scheduleCommand(clearValidationCacheCommand);
         }
     }
 


### PR DESCRIPTION
The interface declaration is not mandatory so it may be required even without it.