### PR TITLE
Added support to attach agent runtime to JVM process

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ This project is still in a beta version.
 ### Easy to start
 Download and install latest [DCEVM Java patch](https://github.com/dcevm/dcevm/releases) +
 [agent jar](https://github.com/HotswapProjects/HotswapAgent/releases) and launch your application server
-with options `-XXaltjvm=dcevm -javaagent:hotswap-agent.jar` to get basic setup.
-Optionally add hotswap-agent.properties to your application to configure plugins and agent behaviour.
+with options `-XXaltjvm=dcevm -javaagent:hotswap-agent.jar` to get basic setup. You can attach [agent jar](https://github.com/HotswapProjects/HotswapAgent/releases) to the running JVM using the following example [code snippet](https://gist.github.com/xnike/a268fc209df52bf1bf09a268e97cef53). Optionally add hotswap-agent.properties to your application to configure plugins and agent behaviour.
 
 ### Plugins
 Each application framework (Spring, Hibernate, Logback, ...) needs special reloading mechanism to keep
@@ -41,7 +40,7 @@ unpack `hotswap-agent.jar` and put it anywhere on your disc. For example: `C:\ja
 1. add following command line java attributes: `-XXaltjvm=dcevm -javaagent:PATH_TO_AGENT\hotswap-agent.jar` (you
 need to replace PATH_TO_AGENT with an actual) directory. For example `java -XXaltjvm=dcevm -javaagent:c:\java\hotswap-agent.jar YourApp`.
   See [IntelliJ IDEA](https://groups.google.com/forum/#!topic/hotswapagent/BxAK_Clniss)
-  and [Netbeans](https://groups.google.com/forum/#!topic/hotswapagent/ydW5bQMwQqU) forum threads for IDE specific setup guides.
+  and [Netbeans](https://groups.google.com/forum/#!topic/hotswapagent/ydW5bQMwQqU) forum threads for IDE specific setup guides. If your application is already running, you still can attach agent jar using the example [code snippet](https://gist.github.com/xnike/a268fc209df52bf1bf09a268e97cef53).
 1. (optional) create a file named "hotswap-agent.properties" inside your resources directory, see available properties and
   default values: <https://github.com/HotswapProjects/HotswapAgent/blob/master/hotswap-agent-core/src/main/resources/hotswap-agent.properties>
 1. start the application in debug mode, check that the agent and plugins are initialized correctly:

--- a/hotswap-agent-core/README.md
+++ b/hotswap-agent-core/README.md
@@ -6,7 +6,7 @@ Hotswap agent is a plugin container with plugin manager, plugin registry, and se
 
 Agent structure
 ---------------
-The agent is initialized as a javaagent (see META-INF/MANIFEST.MF registration of `HotswapAgent.premain()`). This in turn
+The agent is initialized as a javaagent (at JVM startup see META-INF/MANIFEST.MF registration of `HotswapAgent.premain()`, when JVM running see META-INF/MANIFEST.MF registration of `HotswapAgent.agentmain()`). This in turn
 initialize the singleton agent class `PluginManager`. You can always use `PluginManager.getInstance()` to access the agent,
 although it is usually better to use plugin custom "dependency injection" via @Init annotation to access agent services.
 

--- a/hotswap-agent-core/pom.xml
+++ b/hotswap-agent-core/pom.xml
@@ -75,6 +75,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
+                            <Agent-Class>org.hotswap.agent.HotswapAgent</Agent-Class>
                             <Premain-Class>org.hotswap.agent.HotswapAgent</Premain-Class>
                             <Can-Redefine-Classes>true</Can-Redefine-Classes>
                             <Can-Retransform-Classes>true</Can-Retransform-Classes>

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/HotswapAgent.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/HotswapAgent.java
@@ -13,6 +13,7 @@ import java.util.Set;
  * Register the agent and initialize plugin manager singleton instance.
  * <p/>
  * This class must be registered in META-INF/MANIFEST.MF:
+ * Agent-Class: org.hotswap.agent.HotswapAgent
  * Premain-Class: org.hotswap.agent.HotswapAgent
  * <p/>
  * Use with -javaagent agent.jar to use with an application.
@@ -39,13 +40,17 @@ public class HotswapAgent {
      */
     private static String propertiesFilePath;
 
+    public static void agentmain(String args, Instrumentation inst) {
+        premain(args, inst);
+    }
+
     public static void premain(String args, Instrumentation inst) {
 
         LOGGER.info("Loading Hotswap agent {{}} - unlimited runtime class redefinition.", Version.version());
         parseArgs(args);
         fixJboss7Modules();
         PluginManager.getInstance().init(inst);
-        LOGGER.debug("Hotswap agent inicialized.");
+        LOGGER.debug("Hotswap agent initialized.");
 
     }
 

--- a/hotswap-agent/pom.xml
+++ b/hotswap-agent/pom.xml
@@ -195,6 +195,7 @@
                                 <manifestEntries>
                                     <Implementation-Title>${project.build.finalName}</Implementation-Title>
                                     <Implementation-Version>${project.version}</Implementation-Version>
+                                    <Agent-Class>org.hotswap.agent.HotswapAgent</Agent-Class>
                                     <Premain-Class>org.hotswap.agent.HotswapAgent</Premain-Class>
                                     <!-- <Boot-Class-Path>hotswap-agent.jar</Boot-Class-Path>  -->
                                     <Can-Redefine-Classes>true</Can-Redefine-Classes>


### PR DESCRIPTION
Sometime it's useful to attach to running JVM process and reload class
with version containing more writing to log entries using Hotswapper
plugin. This helps to investigate rarely heppenning issues, because
restarting JVM with agent doesn't guarantee reproducing of the issues.

PFA example how to attach hotswap-agent.jar to running JVM process:
[AgentRunner.java.txt](https://github.com/HotswapProjects/HotswapAgent/files/475203/AgentRunner.java.txt)
