### PR TITLE
Modify the ClassPathScanner to support URIs prefixed with "zip:"

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/util/scanner/ClassPathScanner.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/util/scanner/ClassPathScanner.java
@@ -25,6 +25,7 @@ public class ClassPathScanner implements Scanner {
     // scan for files inside JAR file - e.g. jar:file:\J:\HotswapAgent\target\HotswapAgent-1.0.jar!\org\hotswap\agent\plugin
     public static final String JAR_URL_SEPARATOR = "!/";
     public static final String JAR_URL_PREFIX = "jar:";
+    public static final String ZIP_URL_PREFIX = "zip:";
     public static final String FILE_URL_PREFIX = "file:";
 
 
@@ -47,8 +48,8 @@ public class ClassPathScanner implements Scanner {
                     throw new IOException("Illegal directory URI " + pluginDirURL, e);
                 }
 
-                if (uri.startsWith(JAR_URL_PREFIX)) {
-                    String jarFile = uri.substring(JAR_URL_PREFIX.length());
+                if (uri.startsWith(JAR_URL_PREFIX) || uri.startsWith(ZIP_URL_PREFIX)) {
+                    String jarFile = uri.substring(uri.indexOf(':') + 1); // remove the prefix
                     scanJar(jarFile, visitor);
                 } else {
                     LOGGER.warning("Unknown resource type of file " + uri);


### PR DESCRIPTION
In my deployment in WebLogic 12 the classloader returns the JAR files of
the web application prefixed with "zip:" instead of "jar:". That prevents
us from loading our custom plugin.

The jar files are taken from the standard WAR location (WEB-INF/lib/)

Example of an error:
```
<BEA-000000> <HOTSWAP AGENT: 6:3:56.322 WARNING (org.hotswap.agent.util.scanner.ClassPathScanner) - Unknown resource type of file zip:/opt/web-app/WEB-INF/lib/dev-tools.jar!/com/acme/hotswap/agent/plugin/acme>
```