### PR TITLE
Add Support for Hibernate 4.2 in Spring. 

### DIFF
--- a/plugin/hotswap-agent-hibernate-plugin/src/main/java/org/hotswap/agent/plugin/hibernate/HibernateTransformers.java
+++ b/plugin/hotswap-agent-hibernate-plugin/src/main/java/org/hotswap/agent/plugin/hibernate/HibernateTransformers.java
@@ -22,7 +22,7 @@ public class HibernateTransformers {
      * <p/>
      * After the entity manager factory and it's proxy are instantiated, plugin init method is invoked.
      */
-    @OnClassLoadEvent(classNameRegexp = "(org.hibernate.ejb.HibernatePersistence)|(org.hibernate.jpa.HibernatePersistenceProvider)|(org.springframework.orm.jpa.vendor.SpringHibernateJpaPersistenceProvider)")
+    @OnClassLoadEvent(classNameRegexp = "(org.hibernate.ejb.HibernatePersistence)|(org.hibernate.jpa.HibernatePersistenceProvider)|(org.springframework.orm.jpa.vendor.SpringHibernateJpaPersistenceProvider)|(org.springframework.orm.jpa.vendor.SpringHibernateEjbPersistenceProvider)")
     public static void proxyHibernatePersistence(CtClass clazz) throws Exception {
         LOGGER.debug("Override org.hibernate.ejb.HibernatePersistence#createContainerEntityManagerFactory and createEntityManagerFactory to create a EntityManagerFactoryProxy proxy.");
 


### PR DESCRIPTION
Add the other spring implementation class that was missing. 
See https://github.com/spring-projects/spring-framework/blob/4.2.x/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/HibernateJpaVendorAdapter.java#L91.