### PR TITLE
tomcat artifact flexibility

### DIFF
--- a/plugin/hotswap-agent-tomcat-plugin/pom.xml
+++ b/plugin/hotswap-agent-tomcat-plugin/pom.xml
@@ -10,6 +10,12 @@
     </parent>
 
     <artifactId>hotswap-agent-tomcat-plugin</artifactId>
+    
+    <properties>
+        <tomcat.version>6.0.36</tomcat.version>
+        <tomcat.artifact>catalina</tomcat.artifact> <!-- catalina if 6.x -->
+        <!-- <tomcat.artifact>tomcat-catalina</tomcat.artifact> --> <!-- tomcat-catalina if 7.x+ -->
+    </properties>
 
     <dependencies>
         <dependency>
@@ -21,10 +27,8 @@
         <!--Just to get Tomcat sources into IDE-->
         <dependency>
             <groupId>org.apache.tomcat</groupId>
-            <artifactId>catalina</artifactId>
-            <!--<version>7.0.47</version>-->
-            <!--<version>8.0.1</version>-->
-            <version>6.0.36</version> <!--(change artifcatId to catalina) -->
+            <artifactId>${tomcat.artifact}</artifactId>
+            <version>${tomcat.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
i have added some flexibility and (really) minor documentation to build the tomcat-plugin against versions 6.x and 7.x+ of tomcat, which have different artifactId. perhaps create a tomcat6 only plugin (for compat reasons) and newer versions with the new artifactId? just a thought ...