### PR TITLE
Issue 197

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginConfiguration.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginConfiguration.java
@@ -258,18 +258,8 @@ public class PluginConfiguration {
     /**
      * Return configuration property webappDir as URL.
      */
-    public URL getWebappDir() {
-        try {
-            String webappDir = getProperty("webappDir");
-            if (webappDir != null && webappDir.length() > 0) {
-                return resourceNameToURL(webappDir);
-            } else {
-                return null;
-            }
-        } catch (Exception e) {
-            LOGGER.error("Invalid configuration value for webappDir: '{}' is not a valid URL or path and will be skipped.", getProperty("webappDir"), e);
-            return null;
-        }
+    public URL[] getWebappDir() {
+        return convertToURL(getProperty("webappDir"));
     }
 
     /**

--- a/plugin/hotswap-agent-jetty-plugin/src/main/java/org/hotswap/agent/plugin/jetty/JettyPlugin.java
+++ b/plugin/hotswap-agent-jetty-plugin/src/main/java/org/hotswap/agent/plugin/jetty/JettyPlugin.java
@@ -155,12 +155,12 @@ public class JettyPlugin {
         }
 
         // set different resource
-        URL webappDir = pluginConfiguration.getWebappDir();
-        if (webappDir != null) {
-            LOGGER.debug("Setting webappDir to directory '{}' for Jetty webapp {}.", webappDir, contextHandler);
+        URL[] webappDir = pluginConfiguration.getWebappDir();
+        if (webappDir.length > 0) {
+            LOGGER.debug("Setting webappDir to directory '{}' for Jetty webapp {}.", webappDir[0], contextHandler);
             try {
                 Object originalBaseResource = ReflectionHelper.invoke(contextHandler, contextHandlerClass, "getBaseResource", new Class[] {});
-                Object fileResource = fileResourceClass.getDeclaredConstructor(URL.class).newInstance(webappDir);
+                Object fileResource = fileResourceClass.getDeclaredConstructor(URL.class).newInstance(webappDir[0]);
                 Object resourceArray = Array.newInstance(resourceClass, 2);
                 Array.set(resourceArray, 0, fileResource);
                 Array.set(resourceArray, 1, originalBaseResource);
@@ -171,7 +171,7 @@ public class JettyPlugin {
                         new Class[] {resourceClass}, resourceCollection);
 
             } catch (Exception e) {
-                LOGGER.error("Unable to set webappDir to directory '{}' for Jetty webapp {}. This configuration will not work.", e, webappDir, contextHandler);
+                LOGGER.error("Unable to set webappDir to directory '{}' for Jetty webapp {}. This configuration will not work.", e, webappDir[0], contextHandler);
             }
         }
 

--- a/plugin/hotswap-agent-jetty-plugin/src/main/java/org/hotswap/agent/plugin/jetty/JettyPlugin.java
+++ b/plugin/hotswap-agent-jetty-plugin/src/main/java/org/hotswap/agent/plugin/jetty/JettyPlugin.java
@@ -157,21 +157,26 @@ public class JettyPlugin {
         // set different resource
         URL[] webappDir = pluginConfiguration.getWebappDir();
         if (webappDir.length > 0) {
-            LOGGER.debug("Setting webappDir to directory '{}' for Jetty webapp {}.", webappDir[0], contextHandler);
             try {
-                Object originalBaseResource = ReflectionHelper.invoke(contextHandler, contextHandlerClass, "getBaseResource", new Class[] {});
-                Object fileResource = fileResourceClass.getDeclaredConstructor(URL.class).newInstance(webappDir[0]);
-                Object resourceArray = Array.newInstance(resourceClass, 2);
-                Array.set(resourceArray, 0, fileResource);
-                Array.set(resourceArray, 1, originalBaseResource);
-
-                Object resourceCollection = resourceCollectionClass.getDeclaredConstructor(resourceArray.getClass()).newInstance(resourceArray);
+                Object originalBaseResource = ReflectionHelper.invoke(contextHandler, contextHandlerClass,
+                        "getBaseResource", new Class[] {});
+                Object resourceArray = Array.newInstance(resourceClass, webappDir.length + 1);
+                for (int i = 0; i < webappDir.length; i++) {
+                    LOGGER.debug("Watching 'webappDir' for changes: {} in Jetty webapp: {}", webappDir[i],
+                            contextHandler);
+                    Object fileResource = fileResourceClass.getDeclaredConstructor(URL.class).newInstance(webappDir[i]);
+                    Array.set(resourceArray, i, fileResource);
+                }
+                Array.set(resourceArray, webappDir.length, originalBaseResource);
+                Object resourceCollection = resourceCollectionClass.getDeclaredConstructor(resourceArray.getClass())
+                        .newInstance(resourceArray);
 
                 ReflectionHelper.invoke(contextHandler, contextHandlerClass, "setBaseResource",
-                        new Class[] {resourceClass}, resourceCollection);
-
+                        new Class[] { resourceClass }, resourceCollection);
             } catch (Exception e) {
-                LOGGER.error("Unable to set webappDir to directory '{}' for Jetty webapp {}. This configuration will not work.", e, webappDir[0], contextHandler);
+                LOGGER.error(
+                        "Unable to set webappDir to directory '{}' for Jetty webapp {}. This configuration will not work.",
+                        e, webappDir[0], contextHandler);
             }
         }
 


### PR DESCRIPTION
Added support for multiple entries to `webappDir` property for Tomcat.

Added fully qualified name for `ParallelWebappClassLoader`which was introduced in a later version of Tomcat 8. Without this change the `webappDir` was never loaded.

Had to modify a class in the Jetty plugin to accommodate for receiving an array now.
