### PR TITLE
Better fix for #78 : support for wildcards in component-scan base-package

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/util/HotswapTransformer.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/util/HotswapTransformer.java
@@ -285,16 +285,12 @@ public class HotswapTransformer implements ClassFileTransformer {
 
     /**
      * Transform type to ^regexp$ form - match only whole pattern.
-     * Additionally, remove Ant path style ** with .*.
      *
      * @param registeredType type
      * @return
      */
     protected String normalizeTypeRegexp(String registeredType) {
         String regexp = registeredType;
-        while (regexp.contains("**")){
-            regexp = regexp.replace("**", ".*");
-        }
         if (!registeredType.startsWith("^")){
             regexp = "^" + regexp;
         }

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/SpringPlugin.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/SpringPlugin.java
@@ -73,7 +73,7 @@ public class SpringPlugin {
     public void registerComponentScanBasePackage(final String basePackage) {
         LOGGER.info("Registering basePackage {}", basePackage);
         final SpringChangesAnalyzer analyzer = new SpringChangesAnalyzer(appClassLoader);
-        hotswapTransformer.registerTransformer(appClassLoader, basePackage + ".*", new ClassFileTransformer() {
+        hotswapTransformer.registerTransformer(appClassLoader, getClassNameRegExp(basePackage), new ClassFileTransformer() {
             @Override
             public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
                 if (classBeingRedefined != null) {
@@ -88,7 +88,7 @@ public class SpringPlugin {
 
         Enumeration<URL> resourceUrls = null;
         try {
-            resourceUrls = appClassLoader.getResources(basePackage.replace(".", "/"));
+            resourceUrls = getResources(basePackage);
         } catch (IOException e) {
             LOGGER.error("Unable to resolve base package {} in classloader {}.", basePackage, appClassLoader);
             return;
@@ -118,7 +118,7 @@ public class SpringPlugin {
                             if (!ClassLoaderHelper.isClassLoaded(appClassLoader, className)) {
                                 // refresh spring only for new classes
                                 scheduler.scheduleCommand(new ClassPathBeanRefreshCommand(appClassLoader,
-                                        basePackage, event), WAIT_ON_CREATE);
+                                        basePackage, className, event), WAIT_ON_CREATE);
                             }
                         }
                     }
@@ -127,6 +127,31 @@ public class SpringPlugin {
         }
     }
 
+    private String getClassNameRegExp(String basePackage) {
+        String regexp = basePackage;
+        while (regexp.contains("**")) {
+            regexp = regexp.replace("**", ".*");
+        }
+        if (!regexp.endsWith(".*")) {
+            regexp += ".*";
+        }
+        return regexp;
+    }
+
+    private Enumeration<URL> getResources(String basePackage) throws IOException {
+        String resourceName = basePackage;
+        int index = resourceName.indexOf('*');
+        if (index != -1) {
+            resourceName = resourceName.substring(0, index);
+            index = resourceName.lastIndexOf('.');
+            if (index != -1) {
+                resourceName = resourceName.substring(0, index);
+            }
+        }
+        resourceName = resourceName.replace('.', '/');
+        return appClassLoader.getResources(resourceName);
+    }
+    
     /**
      * Plugin initialization is after Spring has finished its startup and freezeConfiguration is called.
      *

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/ClassPathBeanRefreshCommand.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/ClassPathBeanRefreshCommand.java
@@ -37,16 +37,11 @@ public class ClassPathBeanRefreshCommand extends MergeableCommand {
         this.classDefinition = classDefinition;
     }
 
-    public ClassPathBeanRefreshCommand(ClassLoader appClassLoader, String basePackage, WatchFileEvent event) {
+    public ClassPathBeanRefreshCommand(ClassLoader appClassLoader, String basePackage, String className, WatchFileEvent event) {
         this.appClassLoader = appClassLoader;
         this.basePackage = basePackage;
         this.event = event;
-
-        // strip from URI prefix up to basePackage and .class suffix.
-        String path = event.getURI().getPath();
-        path = path.substring(path.indexOf(basePackage.replace(".", "/")));
-        path = path.substring(0, path.indexOf(".class"));
-        this.className = path;
+        this.className = className;
     }
 
     @Override

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/ComponentScanWithWildcardsTest.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/ComponentScanWithWildcardsTest.java
@@ -1,0 +1,134 @@
+package org.hotswap.agent.plugin.spring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+
+import org.hotswap.agent.javassist.ClassPool;
+import org.hotswap.agent.javassist.CtClass;
+import org.hotswap.agent.javassist.LoaderClassPath;
+import org.hotswap.agent.plugin.hotswapper.HotSwapper;
+import org.hotswap.agent.plugin.spring.scanner.ClassPathBeanDefinitionScannerAgent;
+import org.hotswap.agent.plugin.spring.wildcardstest.beans.hotswap.BeanServiceImpl2;
+import org.hotswap.agent.plugin.spring.wildcardstest.beans.hotswap.NewHelloServiceImpl;
+import org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans.BeanService;
+import org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans.BeanServiceImpl;
+import org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans.NewHelloService;
+import org.hotswap.agent.util.test.WaitHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Tests when the application context file is using component-scan with wildcards
+ * 
+ * See maven setup for javaagent and autohotswap settings.
+ * 
+ * @author Cedric Chabanois
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath:wildcardsApplicationContext.xml" })
+public class ComponentScanWithWildcardsTest {
+
+    @Autowired
+    AutowireCapableBeanFactory factory;
+
+    @Test
+    public void testHotswapService() throws Exception {
+        BeanServiceImpl bean = factory.getBean(BeanServiceImpl.class);
+        try {
+            // Given
+            assertEquals("Hello from Repository ServiceWithAspect", bean.hello());
+
+            // When
+            swapClasses(BeanServiceImpl.class, BeanServiceImpl2.class.getName());
+
+            // Then
+            assertEquals("Hello from ChangedRepository Service2WithAspect", bean.hello());
+            assertEquals("Hello from ChangedRepository Service2WithAspect", factory.getBean(BeanService.class).hello());
+        } finally {
+            swapClasses(BeanServiceImpl.class, BeanServiceImpl.class.getName());
+            assertEquals("Hello from Repository ServiceWithAspect", bean.hello());
+        }
+    }
+
+    @Test
+    public void testNewServiceClassFile() throws Exception {
+        File file = null;
+        try {
+            // Given
+            assertNoBean(NewHelloService.class);
+
+            // When
+            file = copyClassFileAndWaitForReload(NewHelloServiceImpl.class,
+                    "org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans.NewHelloServiceImpl");
+
+            // Then
+            assertEquals("Hello from Repository NewHelloServiceWithAspect",
+                    factory.getBean(NewHelloService.class).hello());
+        } finally {
+            if (file != null) {
+                // we don't reload on delete
+                file.delete();
+            }
+        }
+    }
+
+    private void assertNoBean(Class<?> clazz) {
+        try {
+            factory.getBean(clazz);
+            fail();
+        } catch (NoSuchBeanDefinitionException e) {
+
+        }
+    }
+
+    private void swapClasses(Class<?> original, String swap) throws Exception {
+        ClassPathBeanDefinitionScannerAgent.reloadFlag = true;
+        HotSwapper.swapClasses(original, swap);
+        waitForReload(1000);
+    }
+
+    public static File copyClassFileAndWaitForReload(Class<?> clazz, String newName) throws Exception {
+        ClassPathBeanDefinitionScannerAgent.reloadFlag = true;
+        File file = copyClassFile(clazz, newName);
+        try {
+            waitForReload(10000);
+        } catch (Throwable e) {
+            file.delete();
+            throw e;
+        }
+        return file;
+    }
+
+    private static void waitForReload(int timeout) throws InterruptedException {
+        assertTrue(WaitHelper.waitForCommand(new WaitHelper.Command() {
+            @Override
+            public boolean result() throws Exception {
+                return !ClassPathBeanDefinitionScannerAgent.reloadFlag;
+            }
+        }, timeout));
+        // TODO do not know why sleep is needed, maybe a separate thread in Spring
+        // refresh?
+        Thread.sleep(100);
+    }
+
+    public static File copyClassFile(Class<?> clazz, String newName) throws Exception {
+        String directoryName = clazz.getClassLoader().getResource("").getPath();
+        ClassPool classPool = new ClassPool();
+        classPool.appendClassPath(new LoaderClassPath(clazz.getClassLoader()));
+        CtClass ctClass = classPool.getAndRename(clazz.getName(), newName);
+        ctClass.writeFile(directoryName);
+        File file = new File(directoryName + File.separatorChar + newName.replace('.', File.separatorChar) + ".class");
+        assertTrue(file.exists());
+        return file;
+    }
+
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/hotswap/BeanServiceImpl2.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/hotswap/BeanServiceImpl2.java
@@ -1,0 +1,24 @@
+package org.hotswap.agent.plugin.spring.wildcardstest.beans.hotswap;
+
+
+import org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans.BeanChangedRepository;
+import org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans.BeanService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BeanServiceImpl2 implements BeanService {
+	String name = "Service2";
+	
+    @Autowired
+    BeanChangedRepository beanRepository;
+    
+    public String hello() {
+        return beanRepository.hello() + " " + name;
+    }
+	
+    public String hello2() {
+        return beanRepository.hello() + name;
+    } 
+    
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/hotswap/NewHelloServiceImpl.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/hotswap/NewHelloServiceImpl.java
@@ -1,0 +1,18 @@
+package org.hotswap.agent.plugin.spring.wildcardstest.beans.hotswap;
+
+import org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans.BeanRepository;
+import org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans.NewHelloService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NewHelloServiceImpl implements NewHelloService {
+
+    @Autowired
+    BeanRepository beanRepository;
+
+    public String hello() {
+        return beanRepository.hello() + " NewHelloService";
+    }	
+	
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/BeanChangedRepository.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/BeanChangedRepository.java
@@ -1,0 +1,13 @@
+package org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans;
+
+import org.springframework.stereotype.Repository;
+
+/**
+ * Change to this repository to check reinitialization after hotswap.
+ */
+@Repository
+public class BeanChangedRepository {
+    public String hello() {
+        return "Hello from ChangedRepository";
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/BeanRepository.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/BeanRepository.java
@@ -1,0 +1,13 @@
+package org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans;
+
+import org.springframework.stereotype.Repository;
+
+/**
+ * Basic repository bean
+ */
+@Repository
+public class BeanRepository {
+    public String hello() {
+        return "Hello from Repository";
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/BeanService.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/BeanService.java
@@ -1,0 +1,5 @@
+package org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans;
+
+public interface BeanService {
+    public String hello();
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/BeanServiceImpl.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/BeanServiceImpl.java
@@ -1,0 +1,16 @@
+package org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BeanServiceImpl implements BeanService {
+
+    @Autowired
+    BeanRepository beanRepository;
+
+    public String hello() {
+        return beanRepository.hello() + " Service";
+    }	
+	
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/NewHelloService.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/NewHelloService.java
@@ -1,0 +1,5 @@
+package org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans;
+
+public interface NewHelloService {
+    public String hello();
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/TestAspect.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/wildcardstest/beans/testbeans/TestAspect.java
@@ -1,0 +1,17 @@
+package org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+/**
+ * Test aspect. While aspect reloading is not yet supported, it is used
+ * to test reload of proxy around a service. It can be created by @Transactional etc.
+ */
+@Aspect
+public class TestAspect {
+    @Around("execution(* org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans.*Service.hello(..))")
+    public Object around(ProceedingJoinPoint pjp) throws Throwable {
+        return pjp.proceed() + "WithAspect";
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/resources/wildcardsApplicationContext.xml
+++ b/plugin/hotswap-agent-spring-plugin/src/test/resources/wildcardsApplicationContext.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+           http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+           http://www.springframework.org/schema/context
+           http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+    <aop:aspectj-autoproxy proxy-target-class="true"/>
+
+    <bean class="org.hotswap.agent.plugin.spring.wildcardstest.beans.testbeans.TestAspect"/>
+
+	<!-- component scan with wilcards -->
+	<context:component-scan base-package="org.hotswap.agent.plugin.spring.wildcardstest.**.testbeans.**"/>
+
+</beans>


### PR DESCRIPTION
SpringPlugin registers both a hotswap transformer AND watcher but with previous fix no watcher was registered when basePackage had wildcards.
Also I think fix should be in SpringPlugin, not in HotswapTransformer.
Also added some tests.