### PR TITLE
HotswapperPlugin: listen also to FileEvent.CREATE

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/plugin/hotswapper/HotswapperPlugin.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/plugin/hotswapper/HotswapperPlugin.java
@@ -51,7 +51,7 @@ public class HotswapperPlugin {
     /**
      * For each changed class create a reload command.
      */
-    @OnClassFileEvent(classNameRegexp = ".*", events = {FileEvent.MODIFY})
+    @OnClassFileEvent(classNameRegexp = ".*", events = {FileEvent.MODIFY, FileEvent.CREATE})
     public void watchReload(CtClass ctClass, ClassLoader appClassLoader, URL url) throws IOException, CannotCompileException {
         if (!ClassLoaderHelper.isClassLoaded(appClassLoader, ctClass.getName())) {
             LOGGER.trace("Class {} not loaded yet, no need for autoHotswap, skipped URL {}", ctClass.getName(), url);


### PR DESCRIPTION
In some environments (especially Gradle + Kotlin + Mac OS), the old class files are removed before newly compiled files are written to file system. In this case WatchService generate ENTRY_DELETE and ENTRY_CREATE instead of just ENTRY_MODIFY. That means HotswapperPlugin does not detect changes in class files.
The change in the pull request makes the plugin listen to ENTRY_CREATE as well.