### PR TITLE
Add Wicket plugin

### DIFF
--- a/plugin/hotswap-agent-wicket-plugin/README.md
+++ b/plugin/hotswap-agent-wicket-plugin/README.md
@@ -1,0 +1,10 @@
+[Apache Wicket](https://wicket.apache.org/)
+====================================
+
+Wicket is an open source, component oriented, serverside, Java web application framework. 
+
+To create a Wicket project, go to https://wicket.apache.org/start/quickstart.html
+
+#### Features
+* Localizer caches are cleared whenever a property file is changed
+

--- a/plugin/hotswap-agent-wicket-plugin/pom.xml
+++ b/plugin/hotswap-agent-wicket-plugin/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.hotswapagent</groupId>
+        <artifactId>hotswap-agent-parent</artifactId>
+        <version>1.3.1-SNAPSHOT</version>
+        <relativePath>../../hotswap-agent-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hotswap-agent-wicket-plugin</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hotswapagent</groupId>
+            <artifactId>hotswap-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugin/hotswap-agent-wicket-plugin/src/main/java/org/hotswap/agent/plugin/wicket/WicketPlugin.java
+++ b/plugin/hotswap-agent-wicket-plugin/src/main/java/org/hotswap/agent/plugin/wicket/WicketPlugin.java
@@ -1,0 +1,90 @@
+package org.hotswap.agent.plugin.wicket;
+
+import org.hotswap.agent.annotation.Init;
+import org.hotswap.agent.annotation.OnClassLoadEvent;
+import org.hotswap.agent.annotation.OnResourceFileEvent;
+import org.hotswap.agent.annotation.Plugin;
+import org.hotswap.agent.command.Scheduler;
+import org.hotswap.agent.javassist.CannotCompileException;
+import org.hotswap.agent.javassist.CtClass;
+import org.hotswap.agent.javassist.NotFoundException;
+import org.hotswap.agent.logging.AgentLogger;
+import org.hotswap.agent.util.PluginManagerInvoker;
+
+import java.lang.reflect.Method;
+
+/**
+ * Wicket hotswap support
+ *
+ * https://wicket.apache.org
+ *
+ * @author Thomas Heigl
+ */
+@Plugin(name = "Wicket", description = "Wicket support", testedVersions = "8.0.0", expectedVersions = "8.x")
+public class WicketPlugin {
+
+    private static final String WICKET_APPLICATION = "org.apache.wicket.protocol.http.WebApplication";
+
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(WicketPlugin.class);
+
+    @Init
+    Scheduler scheduler;
+    @Init
+    ClassLoader appClassLoader;
+
+    private Object wicketApplication;
+
+    @OnClassLoadEvent(classNameRegexp = WICKET_APPLICATION)
+    public static void init(CtClass ctClass) throws NotFoundException, CannotCompileException {
+        String src = PluginManagerInvoker
+                .buildInitializePlugin(WicketPlugin.class);
+        src += PluginManagerInvoker.buildCallPluginMethod(WicketPlugin.class,
+                "registerApplication", "this", "java.lang.Object");
+        ctClass.getDeclaredConstructor(new CtClass[0]).insertAfter(src);
+
+        LOGGER.info("Wicket application has been enhanced.");
+    }
+
+    public void registerApplication(Object wicketApplication) {
+        this.wicketApplication = wicketApplication;
+
+        LOGGER.info("Plugin {} initialized for application {}", getClass(),
+                wicketApplication);
+    }
+
+    @OnResourceFileEvent(path = "/", filter = ".*.properties")
+    public void clearLocalizerCaches() {
+        scheduler.scheduleCommand(this::clearCache);
+    }
+
+    private void clearCache() {
+        LOGGER.debug("Refreshing Wicket localizer cache.");
+        try {
+            final Object localizer = getLocalizer();
+            final Method clearCacheMethod = resolveClass("org.apache.wicket.Localizer")
+                    .getDeclaredMethod("clearCache");
+            clearCacheMethod.invoke(localizer);
+        } catch (Exception e) {
+            LOGGER.error("Error refreshing Wicket localizer cache", e);
+        }
+    }
+
+    private Object getLocalizer() {
+        try {
+            final Method getResourceSettingsMethod = resolveClass("org.apache.wicket.Application")
+                    .getDeclaredMethod("getResourceSettings");
+            final Method getLocalizerMethod = resolveClass("org.apache.wicket.settings.ResourceSettings")
+                    .getDeclaredMethod("getLocalizer");
+            final Object resourceSettings = getResourceSettingsMethod.invoke(wicketApplication);
+            return getLocalizerMethod.invoke(resourceSettings);
+        } catch (Exception e) {
+            LOGGER.error("Error getting Wicket localizer", e);
+            return null;
+        }
+    }
+
+    private Class<?> resolveClass(String name) throws ClassNotFoundException {
+        return Class.forName(name, true, appClassLoader);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <module>plugin/hotswap-agent-wildfly-el-plugin</module>
         <module>plugin/hotswap-agent-glassfish-plugin</module>
         <module>plugin/hotswap-agent-vaadin-plugin</module>
+        <module>plugin/hotswap-agent-wicket-plugin</module>
         <module>plugin/hotswap-agent-plugins</module>
         <module>hotswap-agent</module>
     </modules>


### PR DESCRIPTION
Initial implementation of a Wicket hotswap plugin.

Currently only clears `Localizer` cache when property files are changed.