### PR TITLE
Add Wicket plugin dependency to agents POM

### DIFF
--- a/plugin/hotswap-agent-plugins/pom.xml
+++ b/plugin/hotswap-agent-plugins/pom.xml
@@ -184,5 +184,11 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.hotswapagent</groupId>
+            <artifactId>hotswap-agent-wicket-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
     </dependencies>
 </project>


### PR DESCRIPTION
I missed adding the new plugin to the agents `pom.xml` in  #278.