### PR TITLE
Fixed issues in plugin CxfJAXRS

### DIFF
--- a/plugin/hotswap-agent-cxf-plugin/src/main/java/org/hotswap/agent/plugin/cxf/jaxrs/CxfJAXRSTransformer.java
+++ b/plugin/hotswap-agent-cxf-plugin/src/main/java/org/hotswap/agent/plugin/cxf/jaxrs/CxfJAXRSTransformer.java
@@ -105,6 +105,7 @@ public class CxfJAXRSTransformer {
             loadMethod.insertAfter( "{ " +
             		"ClassLoader $$cl = java.lang.Thread.currentThread().getContextClassLoader();" +
                     "if ($$cl==null) $$cl = getClass().getClassLoader();" +
+                    PluginManagerInvoker.buildInitializePlugin(CxfJAXRSPlugin.class, "$$cl") +
                     PluginManagerInvoker.buildCallPluginMethod("$$cl", CxfJAXRSPlugin.class, "registerJAXBProvider",
                                 "this", "java.lang.Object") +
                 "}"

--- a/plugin/hotswap-agent-cxf-plugin/src/main/java/org/hotswap/agent/plugin/cxf/jaxrs/CxfJAXRSTransformer.java
+++ b/plugin/hotswap-agent-cxf-plugin/src/main/java/org/hotswap/agent/plugin/cxf/jaxrs/CxfJAXRSTransformer.java
@@ -92,7 +92,6 @@ public class CxfJAXRSTransformer {
             );
             ctClass.addMethod(CtMethod.make(
                     "public void clearSingletonInstance() { this.singletonInstance=null; }", ctClass));
-            ctClass.addMethod(loadMethod);
     } catch(NotFoundException | CannotCompileException e){
             LOGGER.error("Error patching ResourceUtils", e);
         }


### PR DESCRIPTION
When using CxfJAXRS plugin two issue where found in our project:
1. Duplicate method creation when patching JAXRSCdiResourceExtension
Solution: remove not necessary method registration.

2. If application initialize AbstractJAXBProvider before invocation of JAXRSCdiResourceExtension#load or ResourceUtils#createClassResourceInfo initialization failed as plugin method registerJAXBProvider is invoked on not initialized plugin.
Solution: Initilialize plugin also on AbstractJAXBProvider#init method.
