### PR TITLE
cleanup spring plugin unit test

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/pom.xml
+++ b/plugin/hotswap-agent-spring-plugin/pom.xml
@@ -76,7 +76,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
         </dependency>
     </dependencies>
 

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/SpringPluginTest.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/SpringPluginTest.java
@@ -18,10 +18,24 @@
  */
 package org.hotswap.agent.plugin.spring;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.hotswap.agent.plugin.hotswapper.HotSwapper;
 import org.hotswap.agent.plugin.spring.scanner.ClassPathBeanDefinitionScannerAgent;
 import org.hotswap.agent.plugin.spring.scanner.XmlBeanDefinitionScannerAgent;
-import org.hotswap.agent.plugin.spring.testBeans.*;
+import org.hotswap.agent.plugin.spring.testBeans.BeanPrototype;
+import org.hotswap.agent.plugin.spring.testBeans.BeanRepository;
+import org.hotswap.agent.plugin.spring.testBeans.BeanService;
+import org.hotswap.agent.plugin.spring.testBeans.BeanServiceImpl;
+import org.hotswap.agent.plugin.spring.testBeans.Pojo;
 import org.hotswap.agent.plugin.spring.testBeansHotswap.BeanPrototype2;
 import org.hotswap.agent.plugin.spring.testBeansHotswap.BeanRepository2;
 import org.hotswap.agent.plugin.spring.testBeansHotswap.BeanServiceImpl2;
@@ -30,6 +44,7 @@ import org.hotswap.agent.util.ReflectionHelper;
 import org.hotswap.agent.util.spring.io.resource.ClassPathResource;
 import org.hotswap.agent.util.spring.io.resource.Resource;
 import org.hotswap.agent.util.test.WaitHelper;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,14 +55,6 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.channels.FileChannel;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 /**
  * Hotswap class files of spring beans.
  *
@@ -56,11 +63,13 @@ import static org.junit.Assert.assertTrue;
  * @author Jiri Bubnik
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"classpath:applicationContext.xml"})
+@ContextConfiguration(locations = { "classpath:applicationContext.xml" })
 public class SpringPluginTest {
 
     @Autowired
     ApplicationContext applicationContext;
+
+    private Set<Class<?>> swappedClasses;
 
     /**
      * Check correct setup.
@@ -68,90 +77,79 @@ public class SpringPluginTest {
     @Test
     public void basicTest() {
         assertEquals("Hello from Repository ServiceWithAspect", applicationContext.getBean(BeanService.class).hello());
-        assertEquals("Hello from Repository ServiceWithAspect Prototype", applicationContext.getBean(BeanPrototype.class).hello());
+        assertEquals("Hello from Repository ServiceWithAspect Prototype",
+                applicationContext.getBean(BeanPrototype.class).hello());
     }
 
-
     /**
-     * Switch method implementation (using bean definition or interface).
+     * Switch method implementation (using bean definition or interface). Injection
+     * of {@link Autowired @Autowired} dependency is tested as well.
      */
     @Test
     public void hotswapServiceTest() throws Exception {
         BeanServiceImpl bean = applicationContext.getBean(BeanServiceImpl.class);
         assertEquals("Hello from Repository ServiceWithAspect", bean.hello());
-        swapClasses(BeanServiceImpl.class, BeanServiceImpl2.class.getName());
+        swapClasses(BeanServiceImpl.class, BeanServiceImpl2.class);
         assertEquals("Hello from ChangedRepository Service2WithAspect", bean.hello());
         // ensure that using interface is Ok as well
-        assertEquals("Hello from ChangedRepository Service2WithAspect", applicationContext.getBean(BeanService.class).hello());
-
-        // return configuration
-        swapClasses(BeanServiceImpl.class, BeanServiceImpl.class.getName());
-        assertEquals("Hello from Repository ServiceWithAspect", bean.hello());
+        assertEquals("Hello from ChangedRepository Service2WithAspect",
+                applicationContext.getBean(BeanService.class).hello());
     }
-
 
     /**
      * Add new method - invoke via reflection (not available at compilation time).
      */
     @Test
     public void hotswapServiceAddMethodTest() throws Exception {
-        swapClasses(BeanServiceImpl.class, BeanServiceImpl2.class.getName());
+        swapClasses(BeanServiceImpl.class, BeanServiceImpl2.class);
 
+        // get bean via interface
         String helloNewMethodIfaceVal = (String) ReflectionHelper.invoke(applicationContext.getBean(BeanService.class),
                 BeanServiceImpl.class, "helloNewMethod", new Class[] {});
         assertEquals("Hello from helloNewMethod Service2", helloNewMethodIfaceVal);
 
-        String helloNewMethodImplVal = (String) ReflectionHelper.invoke(applicationContext.getBean(BeanServiceImpl.class),
-                BeanServiceImpl.class, "helloNewMethod", new Class[] {});
+        // get bean via implementation
+        String helloNewMethodImplVal = (String) ReflectionHelper.invoke(
+                applicationContext.getBean(BeanServiceImpl.class), BeanServiceImpl.class, "helloNewMethod",
+                new Class[] {});
         assertEquals("Hello from helloNewMethod Service2", helloNewMethodImplVal);
-
-        // return configuration
-        swapClasses(BeanServiceImpl.class, BeanServiceImpl.class.getName());
-        assertEquals("Hello from Repository ServiceWithAspect", applicationContext.getBean(BeanServiceImpl.class).hello());
     }
 
     @Test
     public void hotswapRepositoryTest() throws Exception {
         BeanServiceImpl bean = applicationContext.getBean(BeanServiceImpl.class);
         assertEquals("Hello from Repository ServiceWithAspect", bean.hello());
-        swapClasses(BeanRepository.class, BeanRepository2.class.getName());
+        swapClasses(BeanRepository.class, BeanRepository2.class);
         assertEquals("Hello from ChangedRepository2 ServiceWithAspect", bean.hello());
-
-        // return configuration
-        swapClasses(BeanRepository.class, BeanRepository.class.getName());
-        assertEquals("Hello from Repository ServiceWithAspect", bean.hello());
     }
 
     @Test
     public void hotswapRepositoryNewMethodTest() throws Exception {
-        assertEquals("Hello from Repository ServiceWithAspect", applicationContext.getBean(BeanServiceImpl.class).hello());
-        swapClasses(BeanRepository.class, BeanRepository2.class.getName());
+        assertEquals("Hello from Repository ServiceWithAspect",
+                applicationContext.getBean(BeanServiceImpl.class).hello());
 
-        String helloNewMethodImplVal = (String) ReflectionHelper.invoke(applicationContext.getBean("beanRepository",BeanRepository.class),
-                BeanRepository.class, "helloNewMethod", new Class[] {});
+        swapClasses(BeanRepository.class, BeanRepository2.class);
+
+        String helloNewMethodImplVal = (String) ReflectionHelper.invoke(
+                applicationContext.getBean("beanRepository", BeanRepository.class), BeanRepository.class,
+                "helloNewMethod", new Class[] {});
         assertEquals("Repository new method", helloNewMethodImplVal);
-
-        // return configuration
-        swapClasses(BeanRepository.class, BeanRepository.class.getName());
-        assertEquals("Hello from Repository ServiceWithAspect", applicationContext.getBean(BeanServiceImpl.class).hello());
     }
 
     @Test
     public void hotswapPrototypeTestNewInstance() throws Exception {
-        assertEquals("Hello from Repository ServiceWithAspect Prototype", applicationContext.getBean(BeanPrototype.class).hello());
+        assertEquals("Hello from Repository ServiceWithAspect Prototype",
+                applicationContext.getBean(BeanPrototype.class).hello());
 
         // swap service this prototype is dependent to
-        swapClasses(BeanServiceImpl.class, BeanServiceImpl2.class.getName());
-        assertEquals("Hello from ChangedRepository Service2WithAspect Prototype", applicationContext.getBean(BeanPrototype.class).hello());
+        swapClasses(BeanServiceImpl.class, BeanServiceImpl2.class);
+        assertEquals("Hello from ChangedRepository Service2WithAspect Prototype",
+                applicationContext.getBean(BeanPrototype.class).hello());
 
-        // swap autowired field
-        swapClasses(BeanPrototype.class, BeanPrototype2.class.getName());
+        // swap prototype. New prototype depends directly on repository instead of
+        // service.
+        swapClasses(BeanPrototype.class, BeanPrototype2.class);
         assertEquals("Hello from Repository Prototype2", applicationContext.getBean(BeanPrototype.class).hello());
-
-        // return configuration
-        swapClasses(BeanServiceImpl.class, BeanServiceImpl.class.getName());
-        swapClasses(BeanPrototype.class, BeanPrototype.class.getName());
-        assertEquals("Hello from Repository ServiceWithAspect Prototype", applicationContext.getBean(BeanPrototype.class).hello());
     }
 
     @Test
@@ -159,29 +157,24 @@ public class SpringPluginTest {
         BeanPrototype beanPrototypeInstance = applicationContext.getBean(BeanPrototype.class);
         assertEquals("Hello from Repository ServiceWithAspect Prototype", beanPrototypeInstance.hello());
 
-        swapClasses(BeanServiceImpl.class, BeanServiceImpl2.class.getName());
+        swapClasses(BeanServiceImpl.class, BeanServiceImpl2.class);
         assertEquals("Hello from ChangedRepository Service2WithAspect Prototype", beanPrototypeInstance.hello());
-
-        // return configuration
-        swapClasses(BeanServiceImpl.class, BeanServiceImpl.class.getName());
-        assertEquals("Hello from Repository ServiceWithAspect Prototype", applicationContext.getBean(BeanPrototype.class).hello());
     }
 
     @Test
     public void pojoTest() throws Exception {
-        //Pojo pojo = applicationContext.getAutowireCapableBeanFactory().createBean(Pojo.class);
-
         assertEquals(0, applicationContext.getBeanNamesForType(Pojo.class).length);
-
-        swapClasses(Pojo.class, Pojo2.class.getName());
-
-
+        swapClasses(Pojo.class, Pojo2.class);
         assertEquals(0, applicationContext.getBeanNamesForType(Pojo.class).length);
     }
 
-    private void swapClasses(Class original, String swap) throws Exception {
+    private void swapClasses(Class<?> original, Class<?> swap) throws Exception {
+        if (original.equals(swap))
+            swappedClasses.remove(original);
+        else
+            swappedClasses.add(original);
         ClassPathBeanDefinitionScannerAgent.reloadFlag = true;
-        HotSwapper.swapClasses(original, swap);
+        HotSwapper.swapClasses(original, swap.getName());
         assertTrue(WaitHelper.waitForCommand(new WaitHelper.Command() {
             @Override
             public boolean result() throws Exception {
@@ -189,10 +182,10 @@ public class SpringPluginTest {
             }
         }));
 
-        // TODO do not know why sleep is needed, maybe a separate thread in Spring refresh?
+        // TODO do not know why sleep is needed, maybe a separate thread in Spring
+        // refresh?
         Thread.sleep(100);
     }
-
 
     private static ApplicationContext xmlApplicationContext;
     private static Resource xmlContext = new ClassPathResource("xmlContext.xml");
@@ -200,32 +193,35 @@ public class SpringPluginTest {
     private static Resource xmlContextWithChangedRepo = new ClassPathResource("xmlContextWithChangedRepository.xml");
 
     /*
-        -------Xml test, has to be put in there so xmlContext is load after component scan context-----------
-        (because we don't support multiple component-scan context in single app, or ClassPathBeanDefinitionScannerAgent will
-        not be able to get the right registry to use (it will only use the first one it encountered,
-        Spring tends to reuse ClassPathScanner))
+     * -------Xml test, has to be put in there so xmlContext is load after component
+     * scan context----------- (because we don't support multiple component-scan
+     * context in single app, or ClassPathBeanDefinitionScannerAgent will not be
+     * able to get the right registry to use (it will only use the first one it
+     * encountered, Spring tends to reuse ClassPathScanner))
      */
-
     @Before
-    public void initApplicationCtx() throws IOException {
+    public void before() throws IOException {
+        swappedClasses = new HashSet<>();
         if (xmlApplicationContext == null) {
             writeRepositoryToXml();
             xmlApplicationContext = new ClassPathXmlApplicationContext("xmlContext.xml");
         }
     }
 
+    @After
+    public void after() throws Exception {
+        for (Class<?> cls : new ArrayList<>(swappedClasses))
+            swapClasses(cls, cls);
+    }
+
     private void writeRepositoryToXml() throws IOException {
-        FileChannel src = new FileInputStream(xmlContextWithRepo.getFile()).getChannel();
-        FileChannel dest = new FileOutputStream(xmlContext.getFile()).getChannel();
-        dest.transferFrom(src, 0, src.size());
-        dest.close();
+        Files.copy(xmlContextWithRepo.getFile().toPath(), xmlContext.getFile().toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
     }
 
     private void writeChangedRepositoryToXml() throws IOException {
-        FileChannel src = new FileInputStream(xmlContextWithChangedRepo.getFile()).getChannel();
-        FileChannel dest = new FileOutputStream(xmlContext.getFile()).getChannel();
-        dest.transferFrom(src, 0, src.size());
-        dest.close();
+        Files.copy(xmlContextWithChangedRepo.getFile().toPath(), xmlContext.getFile().toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
     }
 
     @Test


### PR DESCRIPTION
Removed the need to cleanup after every test by keeping a list of swapped classes.