### PR TITLE
Fix Spring MVC Hotswap, Drop Support for old Spring Versions

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/util/ReflectionHelper.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/util/ReflectionHelper.java
@@ -43,7 +43,8 @@ public class ReflectionHelper {
      * @throws IllegalArgumentException if method not found
      * @throws IllegalStateException    for InvocationTargetException (exception in invoked method)
      */
-    public static Object invoke(Object target, Class<?> clazz, String methodName, Class[] parameterTypes, Object... args) {
+    public static Object invoke(Object target, Class<?> clazz, String methodName, Class<?>[] parameterTypes,
+            Object... args) {
         try {
             Method method = null;
             try {
@@ -69,22 +70,58 @@ public class ReflectionHelper {
         }
     }
 
+    /**
+     * Convenience wrapper to reflection method invoke API. Invoke the method and
+     * swallow exceptions due to missing methods. Use this method if you have
+     * multiple framework support and the method may not exist in current version.
+     *
+     * @param target         object to invoke the method on (or null for static
+     *                       methods)
+     * @param clazz          className name
+     * @param cl             Classloader to load the class
+     * @param methodName     method name
+     * @param parameterTypes parameter types to resolve method name
+     * @param args           actual arguments
+     * @return invocation result or null
+     * @throws IllegalStateException for InvocationTargetException (exception in
+     *                               invoked method)
+     */
+    public static Object invokeNoException(Object target, String className, ClassLoader cl, String methodName,
+            Class<?>[] parameterTypes, Object... args) {
+        Class<?> clazz;
+        try {
+            clazz = cl.loadClass(className);
+        } catch (ClassNotFoundException e) {
+            LOGGER.trace("Class {} not found", e, className);
+            return null;
+        }
+
+        try {
+            return invoke(target, clazz, methodName, parameterTypes, args);
+        } catch (IllegalArgumentException e) {
+            LOGGER.trace("Method {}.{} not found", e, className, methodName);
+            return null;
+        }
+    }
 
     /**
-     * Convenience wrapper to reflection method invoke API. Invoke the method and hide checked exceptions.
+     * Convenience wrapper to reflection method invoke API. Invoke the method and
+     * hide checked exceptions.
      *
-     * @param target         object to invoke the method on (or null for static methods)
-     * @param methodName     method name
+     * @param target     object to invoke the method on (or null for static methods)
+     * @param methodName method name
      * @return invocation result or null
      * @throws IllegalArgumentException if method not found
-     * @throws IllegalStateException    for InvocationTargetException (exception in invoked method)
+     * @throws IllegalStateException    for InvocationTargetException (exception in
+     *                                  invoked method)
      */
     public static Object invoke(Object target, String methodName) {
         return invoke(target, target.getClass(), methodName, new Class[] {});
     }
+
     /**
-     * Convenience wrapper to reflection method invoke API. Get field value and hide checked exceptions.
-     * Field class is set by
+     * Convenience wrapper to reflection field access API. Get field value and hide
+     * checked exceptions. Field class is set by
      *
      * @param target    object to get field value (or null for static methods)
      * @param fieldName field name
@@ -95,7 +132,7 @@ public class ReflectionHelper {
         if (target == null)
             throw new NullPointerException("Target object cannot be null.");
 
-        Class clazz = target.getClass();
+        Class<?> clazz = target.getClass();
 
         while (clazz != null) {
             try {
@@ -116,7 +153,8 @@ public class ReflectionHelper {
     }
 
     /**
-     * Convenience wrapper to reflection method invoke API. Get field value and hide checked exceptions.
+     * Convenience wrapper to reflection field access API. Get field value and hide
+     * checked exceptions.
      *
      * @param target    object to get field value (or null for static methods)
      * @param clazz     class name
@@ -137,8 +175,9 @@ public class ReflectionHelper {
     }
 
     /**
-     * Convenience wrapper to reflection method invoke API. Get field value and swallow exceptions.
-     * Use this method if you have multiple framework support and the field may not exist in current version.
+     * Convenience wrapper to reflection field access API. Get field value and
+     * swallow exceptions. Use this method if you have multiple framework support
+     * and the field may not exist in current version.
      *
      * @param target    object to get field value (or null for static methods)
      * @param clazz     class name
@@ -155,12 +194,13 @@ public class ReflectionHelper {
     }
 
     /**
-     * Convenience wrapper to reflection method invoke API. Set field value and hide checked exceptions.
+     * Convenience wrapper to reflection field access API. Set field value and hide
+     * checked exceptions.
      *
      * @param target    object to get field value (or null for static methods)
      * @param clazz     class name
      * @param fieldName field name
-     * @param value field value
+     * @param value     field value
      * @throws IllegalArgumentException if field not found
      */
     public static void set(Object target, Class<?> clazz, String fieldName, Object value) {

--- a/hotswap-agent-parent/pom.xml
+++ b/hotswap-agent-parent/pom.xml
@@ -251,7 +251,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.11</version>
+                <version>4.13</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/plugin/hotswap-agent-spring-plugin/run-tests.sh
+++ b/plugin/hotswap-agent-spring-plugin/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # simple script to run all Spring versions from 3.0 up to latest.
 # this should be replaced by build sever in the future
 
@@ -14,65 +14,6 @@ function test {
 }
 
 # test following Spring versions
-
-test 3.0.1.RELEASE
-test 3.0.2.RELEASE
-test 3.0.3.RELEASE
-test 3.0.4.RELEASE
-test 3.0.5.RELEASE
-test 3.0.6.RELEASE
-test 3.0.7.RELEASE
-test 3.1.0.RELEASE
-test 3.1.1.RELEASE
-test 3.1.2.RELEASE
-test 3.1.3.RELEASE
-test 3.1.4.RELEASE
-
-# Spring 3.2 issues with > Java 1.7
-# see http://stackoverflow.com/questions/22526695/java-1-8-asm-classreader-failed-to-parse-class-file-probably-due-to-a-new-java
-if [[ $JAVA_HOME == *1.7* ]]
-then
-    test 3.2.0.RELEASE
-    test 3.2.1.RELEASE
-    test 3.2.2.RELEASE
-    test 3.2.3.RELEASE
-    test 3.2.4.RELEASE
-    test 3.2.5.RELEASE
-    test 3.2.6.RELEASE
-    test 3.2.7.RELEASE
-    test 3.2.8.RELEASE
-    test 3.2.9.RELEASE
-fi
-
-test 4.0.0.RELEASE
-test 4.0.1.RELEASE
-test 4.0.2.RELEASE
-test 4.0.3.RELEASE
-test 4.0.4.RELEASE
-test 4.0.5.RELEASE
-test 4.0.6.RELEASE
-test 4.0.7.RELEASE
-test 4.0.8.RELEASE
-test 4.0.9.RELEASE
-
-test 4.1.0.RELEASE
-test 4.1.1.RELEASE
-test 4.1.2.RELEASE
-test 4.1.3.RELEASE
-test 4.1.4.RELEASE
-test 4.1.5.RELEASE
-test 4.1.6.RELEASE
-test 4.1.7.RELEASE
-test 4.1.8.RELEASE
-test 4.1.9.RELEASE
-
-test 4.2.0.RELEASE
-test 4.2.1.RELEASE
-test 4.2.2.RELEASE
-test 4.2.3.RELEASE
-test 4.2.4.RELEASE
-test 4.2.5.RELEASE
-test 4.2.6.RELEASE
 
 test 4.3.0.RELEASE
 test 4.3.1.RELEASE
@@ -108,3 +49,4 @@ test 5.1.11.RELEASE
 
 test 5.2.0.RELEASE
 test 5.2.1.RELEASE
+test 5.2.6.RELEASE

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/ResetSpringStaticCaches.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/ResetSpringStaticCaches.java
@@ -18,6 +18,9 @@
  */
 package org.hotswap.agent.plugin.spring;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+
 import org.hotswap.agent.logging.AgentLogger;
 import org.hotswap.agent.util.ReflectionHelper;
 import org.springframework.beans.CachedIntrospectionResults;
@@ -25,9 +28,6 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ReflectionUtils;
-
-import java.lang.reflect.Field;
-import java.util.Map;
 
 /**
  * Reset various Spring static caches. It is safe to run multiple times,
@@ -83,8 +83,14 @@ public class ResetSpringStaticCaches {
         resetTypeVariableCache();
         resetAnnotationUtilsCache();
         resetReflectionUtilsCache();
+        resetResolvableTypeCache();
         resetPropetyCache();
         CachedIntrospectionResults.clearClassLoader(ResetSpringStaticCaches.class.getClassLoader());
+    }
+
+    private static void resetResolvableTypeCache() {
+        ReflectionHelper.invokeNoException(null, "org.springframework.core.ResolvableType",
+                ResetSpringStaticCaches.class.getClassLoader(), "clearCache", new Class<?>[] {});
     }
 
     private static void resetTypeVariableCache() {
@@ -101,7 +107,11 @@ public class ResetSpringStaticCaches {
     }
 
     private static void resetReflectionUtilsCache() {
-        Map declaredMethodsCache = (Map) ReflectionHelper.getNoException(null, ReflectionUtils.class, "declaredMethodsCache");
+        ReflectionHelper.invokeNoException(null, "org.springframework.util.ReflectionUtils",
+                ResetSpringStaticCaches.class.getClassLoader(), "clearCache", new Class<?>[] {});
+
+        Map declaredMethodsCache = (Map) ReflectionHelper.getNoException(null, ReflectionUtils.class,
+                "declaredMethodsCache");
         if (declaredMethodsCache != null) {
             declaredMethodsCache.clear();
             LOGGER.trace("Cache cleared: ReflectionUtils.declaredMethodsCache");
@@ -111,7 +121,11 @@ public class ResetSpringStaticCaches {
     }
 
     private static void resetAnnotationUtilsCache() {
-        Map annotatedInterfaceCache = (Map) ReflectionHelper.getNoException(null, AnnotationUtils.class, "annotatedInterfaceCache");
+        ReflectionHelper.invokeNoException(null, "org.springframework.core.annotation.AnnotationUtils",
+                ResetSpringStaticCaches.class.getClassLoader(), "clearCache", new Class<?>[] {});
+
+        Map annotatedInterfaceCache = (Map) ReflectionHelper.getNoException(null, AnnotationUtils.class,
+                "annotatedInterfaceCache");
         if (annotatedInterfaceCache != null) {
             annotatedInterfaceCache.clear();
             LOGGER.trace("Cache cleared: AnnotationUtils.annotatedInterfaceCache");

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/ClassPathBeanDefinitionScannerAgent.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/ClassPathBeanDefinitionScannerAgent.java
@@ -142,6 +142,8 @@ public class ClassPathBeanDefinitionScannerAgent {
      * @throws IOException error working with classDefinition
      */
     public static void refreshClass(String basePackage, byte[] classDefinition) throws IOException {
+        ResetSpringStaticCaches.reset();
+
         ClassPathBeanDefinitionScannerAgent scannerAgent = getInstance(basePackage);
         if (scannerAgent == null) {
             LOGGER.error("basePackage '{}' not associated with any scannerAgent", basePackage);

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/mvc/SampleRestController.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/mvc/SampleRestController.java
@@ -1,6 +1,8 @@
 package org.hotswap.agent.plugin.spring.mvc;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -9,6 +11,11 @@ public class SampleRestController {
     @GetMapping("/hello")
     public String hello() {
         return "Hello World";
+    }
+
+    @RequestMapping(value = "/helloRequestMapping", method = RequestMethod.GET)
+    public String helloRequestMapping() {
+        return "Hello World2";
     }
 
 }

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/mvc/SpringMvcTest.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/mvc/SpringMvcTest.java
@@ -43,7 +43,13 @@ public class SpringMvcTest {
 
     @Test
     public void changeMappingAndMethodBody() throws Exception {
+        // warm up to fill all caches
+        mockMvc.perform(get("/hello")).andExpect(status().isOk());
+
+        // swap classes
         swappingRule.swapClasses(SampleRestController.class, SampleRestController2.class);
+
+        // make sure classes are swapped
         mockMvc.perform(get("/hello")).andExpect(status().isNotFound());
         mockMvc.perform(get("/helloSwapped")).andExpect(status().isOk())
                 .andExpect(content().string("Hello World Swapped"));

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/mvc/SpringMvcTest.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/mvc/SpringMvcTest.java
@@ -39,10 +39,12 @@ public class SpringMvcTest {
     @Test
     public void baseCase() throws Exception {
         mockMvc.perform(get("/hello")).andExpect(status().isOk()).andExpect(content().string("Hello World"));
+        mockMvc.perform(get("/helloRequestMapping")).andExpect(status().isOk())
+                .andExpect(content().string("Hello World2"));
     }
 
     @Test
-    public void changeMappingAndMethodBody() throws Exception {
+    public void changeGetMappingAndMethodBody() throws Exception {
         // warm up to fill all caches
         mockMvc.perform(get("/hello")).andExpect(status().isOk());
 
@@ -53,6 +55,20 @@ public class SpringMvcTest {
         mockMvc.perform(get("/hello")).andExpect(status().isNotFound());
         mockMvc.perform(get("/helloSwapped")).andExpect(status().isOk())
                 .andExpect(content().string("Hello World Swapped"));
+    }
+
+    @Test
+    public void changeRequestMappingAndMethodBody() throws Exception {
+        // warm up to fill all caches
+        mockMvc.perform(get("/helloRequestMapping")).andExpect(status().isOk());
+
+        // swap classes
+        swappingRule.swapClasses(SampleRestController.class, SampleRestController2.class);
+
+        // make sure classes are swapped
+        mockMvc.perform(get("/helloRequestMapping")).andExpect(status().isNotFound());
+        mockMvc.perform(get("/helloRequestMappingSwapped")).andExpect(status().isOk())
+                .andExpect(content().string("Hello World2 Swapped"));
     }
 
 }

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/mvcHotswap/SampleRestController2.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/mvcHotswap/SampleRestController2.java
@@ -1,6 +1,8 @@
 package org.hotswap.agent.plugin.spring.mvcHotswap;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -9,6 +11,11 @@ public class SampleRestController2 {
     @GetMapping("/helloSwapped")
     public String hello() {
         return "Hello World Swapped";
+    }
+
+    @RequestMapping(value = "/helloRequestMappingSwapped", method = RequestMethod.GET)
+    public String helloRequestMapping() {
+        return "Hello World2 Swapped";
     }
 
 }


### PR DESCRIPTION
To fix Spring MVC Hotswap, some additional static caches have to be cleared. As the spring MVC code and unit test code would not compile under old spring versions, drop support for old spring versions as discussed in #349.