### PR TITLE
Overriding properties from command line using -D

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginConfiguration.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginConfiguration.java
@@ -106,6 +106,10 @@ public class PluginConfiguration {
                     properties.load(configurationURL.openStream());
 
                 }
+                
+                // Add logging properties defined in jvm argument like -DLOGGER=warning
+                System.getProperties().forEach((key, value) -> properties.put(key, value));
+
             } catch (Exception e) {
                 LOGGER.error("Error while loading 'hotswap-agent.properties' from base URL " + configurationURL, e);
             }


### PR DESCRIPTION
Hello,

This is an idea that was discussed in the other pull request. This code override settings from file with -D. It copies all the other arguments and HA does not mind. I could filter the relevant settings but I think it would make things more complex.

I tried overriding the constructor of HotswapProperties.java but, sadly, the settings were overidden by the internal .properties file.

Take care,

Leonard