### PR TITLE
Fixed problem with wrapping exception thrown by original Hibernate Se…

### DIFF
--- a/plugin/hotswap-agent-hibernate-plugin/src/main/java/org/hotswap/agent/plugin/hibernate/proxy/SessionFactoryProxy.java
+++ b/plugin/hotswap-agent-hibernate-plugin/src/main/java/org/hotswap/agent/plugin/hibernate/proxy/SessionFactoryProxy.java
@@ -86,7 +86,12 @@ public class SessionFactoryProxy {
             @Override
             public Object invoke(Object self, Method overridden, Method forwarder,
                                  Object[] args) throws Throwable {
-                return overridden.invoke(currentInstance, args);
+                try {
+                    return overridden.invoke(currentInstance, args);
+                } catch(InvocationTargetException e) {
+                    //rethrow original exception to prevent proxying from changing external behaviour of SessionFactory
+                    throw e.getTargetException();
+                }
             }
         };
 


### PR DESCRIPTION
Fixed problem with wrapping exception thrown by original Hibernate SessionFactory in InvocationTargetException when traversing HotswapAgent proxy by unwraping exception if instance of InvocationTargetException.
    
Previous behaviour was effectively changing API of SessionFactory as one could expecte ex. MappingException and receive InvocationTargetException instead when HotswapAgent is enabled.