### PR TITLE
jackson plugin

### DIFF
--- a/plugin/hotswap-agent-jackson-plugin/README.md
+++ b/plugin/hotswap-agent-jackson-plugin/README.md
@@ -1,0 +1,6 @@
+[Jackson Plugin](https://github.com/FasterXML/jackson)
+==========
+
+JacksonPlugin clears jackson internal caches when class redefined.
+
+

--- a/plugin/hotswap-agent-jackson-plugin/pom.xml
+++ b/plugin/hotswap-agent-jackson-plugin/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.hotswapagent</groupId>
+        <artifactId>hotswap-agent-parent</artifactId>
+        <version>1.4.2-SNAPSHOT</version>
+        <relativePath>../../hotswap-agent-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hotswap-agent-jackson-plugin</artifactId>
+
+    <properties>
+        <jackson.version>2.13.0</jackson.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hotswapagent</groupId>
+            <artifactId>hotswap-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/plugin/hotswap-agent-jackson-plugin/run-tests.sh
+++ b/plugin/hotswap-agent-jackson-plugin/run-tests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# fail with first failed test
+set -e
+
+# run clean package with all unit tests
+function test {
+    echo "################################################################"
+    echo "########             Running with Jackson $1          ###########"
+    echo "################################################################"
+    mvn -Djackson.version=$1 clean package
+}
+
+test 2.13.0

--- a/plugin/hotswap-agent-jackson-plugin/src/main/java/org/hotswap/agent/plugin/jackson/JacksonPlugin.java
+++ b/plugin/hotswap-agent-jackson-plugin/src/main/java/org/hotswap/agent/plugin/jackson/JacksonPlugin.java
@@ -1,0 +1,142 @@
+package org.hotswap.agent.plugin.jackson;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import org.hotswap.agent.annotation.Init;
+import org.hotswap.agent.annotation.LoadEvent;
+import org.hotswap.agent.annotation.OnClassLoadEvent;
+import org.hotswap.agent.annotation.Plugin;
+import org.hotswap.agent.command.Command;
+import org.hotswap.agent.command.Scheduler;
+import org.hotswap.agent.javassist.CannotCompileException;
+import org.hotswap.agent.javassist.CtClass;
+import org.hotswap.agent.javassist.CtConstructor;
+import org.hotswap.agent.javassist.CtMethod;
+import org.hotswap.agent.javassist.CtNewMethod;
+import org.hotswap.agent.javassist.NotFoundException;
+import org.hotswap.agent.logging.AgentLogger;
+import org.hotswap.agent.util.PluginManagerInvoker;
+import org.hotswap.agent.util.ReflectionHelper;
+
+/**
+ * Reload jackson caches after class change
+ *
+ * @author liuzhengyang
+ * 2021/12/3
+ */
+@Plugin(name = "JacksonPlugin",
+        description = "Reload jackson caches after class change",
+        testedVersions = {"2.13.0"},
+        expectedVersions = {"2.13.0"}
+)
+public class JacksonPlugin {
+    private static AgentLogger LOGGER = AgentLogger.getLogger(JacksonPlugin.class);
+
+    private static final String CLEAR_CACHE_METHOD = "ha$$clearCache";
+    public static boolean reloadFlag = false;
+
+    private final Set<Object> objectMappers = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+    private final Set<Object> serializerCaches = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+    private final Set<Object> deserializerCaches = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+    private final Command reloadJacksonCommand = new Command() {
+        public void executeCommand() {
+            reloadFlag = true;
+            try {
+                for (Object obj : objectMappers) {
+                    invokeClearCacheMethod(obj);
+                }
+                for (Object obj : serializerCaches) {
+                    invokeClearCacheMethod(obj);
+                }
+                for (Object obj : deserializerCaches) {
+                    invokeClearCacheMethod(obj);
+                }
+                LOGGER.info("Reloaded Jackson.");
+                reloadFlag = false;
+            } catch (Exception e) {
+                LOGGER.error("Error reloading Jackson.", e);
+            }
+        }
+    };
+
+    @Init
+    private Scheduler scheduler;
+
+    @OnClassLoadEvent(classNameRegexp = ".*", events = LoadEvent.REDEFINE)
+    public void reload() {
+        scheduler.scheduleCommand(reloadJacksonCommand, 500);
+    }
+
+    @OnClassLoadEvent(classNameRegexp = "com.fasterxml.jackson.databind.ObjectMapper", events = LoadEvent.DEFINE, skipSynthetic = false)
+    public static void patchObjectMapper(CtClass clazz) throws NotFoundException, CannotCompileException {
+        LOGGER.debug("Patch {}", clazz);
+        for (CtConstructor constructor : clazz.getDeclaredConstructors()) {
+            StringBuilder src = new StringBuilder("{");
+            src.append(PluginManagerInvoker.buildInitializePlugin(JacksonPlugin.class));
+            src.append(PluginManagerInvoker.buildCallPluginMethod(JacksonPlugin.class, "registerObjectMappers",
+                    "this", "java.lang.Object"));
+            src.append("}");
+            constructor.insertAfter(src.toString());
+        }
+
+        CtMethod clearCacheMethod = CtNewMethod.make("public void " + CLEAR_CACHE_METHOD + "() {_rootDeserializers.clear();}", clazz);
+        clazz.addMethod(clearCacheMethod);
+    }
+
+    @OnClassLoadEvent(classNameRegexp = "com.fasterxml.jackson.databind.ser.SerializerCache", events = LoadEvent.DEFINE, skipSynthetic = false)
+    public static void patchSerializerCache(CtClass clazz) throws NotFoundException, CannotCompileException {
+        LOGGER.debug("Patch {}", clazz);
+        for (CtConstructor constructor : clazz.getDeclaredConstructors()) {
+            StringBuilder src = new StringBuilder("{");
+            src.append(PluginManagerInvoker.buildInitializePlugin(JacksonPlugin.class));
+            src.append(PluginManagerInvoker.buildCallPluginMethod(JacksonPlugin.class, "registerSerializerCaches",
+                    "this", "java.lang.Object"));
+            src.append("}");
+            constructor.insertAfter(src.toString());
+        }
+
+        CtMethod clearCacheMethod = CtNewMethod.make("public void " + CLEAR_CACHE_METHOD + "() {flush();}", clazz);
+        clazz.addMethod(clearCacheMethod);
+    }
+
+    @OnClassLoadEvent(classNameRegexp = "com.fasterxml.jackson.databind.deser.DeserializerCache", events = LoadEvent.DEFINE, skipSynthetic = false)
+    public static void patchDeserializerCache(CtClass clazz) throws NotFoundException, CannotCompileException {
+        LOGGER.debug("Patch {}", clazz);
+        for (CtConstructor constructor : clazz.getDeclaredConstructors()) {
+            StringBuilder src = new StringBuilder("{");
+            src.append(PluginManagerInvoker.buildInitializePlugin(JacksonPlugin.class));
+            src.append(PluginManagerInvoker.buildCallPluginMethod(JacksonPlugin.class, "registerDeserializerCaches",
+                    "this", "java.lang.Object"));
+            src.append("}");
+            constructor.insertAfter(src.toString());
+        }
+
+        CtMethod clearCacheMethod = CtNewMethod.make("public void " + CLEAR_CACHE_METHOD + "() {flushCachedDeserializers();}", clazz);
+        clazz.addMethod(clearCacheMethod);
+    }
+
+    public void registerObjectMappers(Object objectMapper) {
+        objectMappers.add(objectMapper);
+        LOGGER.debug("register {}", objectMapper);
+    }
+
+    public void registerSerializerCaches(Object obj) {
+        serializerCaches.add(obj);
+        LOGGER.debug("register {}", obj);
+    }
+
+    public void registerDeserializerCaches(Object obj) {
+        deserializerCaches.add(obj);
+        LOGGER.debug("register {}", obj);
+    }
+
+    private void invokeClearCacheMethod(Object o) {
+        try {
+            ReflectionHelper.invoke(o, CLEAR_CACHE_METHOD);
+        } catch (Exception e) {
+            LOGGER.error("Reload failed {}", o.getClass(), e);
+        }
+    }
+}

--- a/plugin/hotswap-agent-jackson-plugin/src/test/java/org/hotswap/agent/plugin/jackson/JacksonPluginTest.java
+++ b/plugin/hotswap-agent-jackson-plugin/src/test/java/org/hotswap/agent/plugin/jackson/JacksonPluginTest.java
@@ -1,0 +1,60 @@
+package org.hotswap.agent.plugin.jackson;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import org.hotswap.agent.plugin.hotswapper.HotSwapper;
+import org.hotswap.agent.plugin.jackson.model.TestModel1;
+import org.hotswap.agent.plugin.jackson.model.TestModel2;
+import org.hotswap.agent.util.test.WaitHelper;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author liuzhengyang
+ * 2021/12/3
+ */
+public class JacksonPluginTest {
+    // create object mapper, add field, check object mappers to json from json
+
+
+    @Test
+    public void testAddNewField() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        TestModel1 testModel1 = new TestModel1();
+        testModel1.setAge(1);
+        String json = objectMapper.writeValueAsString(testModel1);
+        assertTrue(json.contains("\"age\":1"));
+
+        // save cache
+        objectMapper.readValue(json, TestModel1.class);
+
+        swapClasses();
+
+        String jsonWithName = "{\"age\":1, \"name\": \"test\"}";
+        TestModel1 readValue = objectMapper.readValue(jsonWithName, TestModel1.class);
+        Field nameField = TestModel1.class.getDeclaredField("name");
+        nameField.setAccessible(true);
+        assertEquals("test", nameField.get(readValue));
+        String value = objectMapper.writeValueAsString(readValue);
+        assertTrue(value.contains("name"));
+    }
+
+    private void swapClasses() throws Exception {
+        assertTrue(Arrays.stream(TestModel1.class.getDeclaredFields()).noneMatch(field -> "name".equals(field.getName())));
+
+        JacksonPlugin.reloadFlag = true;
+        HotSwapper.swapClasses(TestModel1.class, TestModel2.class.getName());
+        assertTrue(WaitHelper.waitForCommand(new WaitHelper.Command() {
+            @Override
+            public boolean result() throws Exception {
+                return !JacksonPlugin.reloadFlag;
+            }
+        }));
+        assertTrue(Arrays.stream(TestModel1.class.getDeclaredFields()).anyMatch(field -> "name".equals(field.getName())));
+    }
+}

--- a/plugin/hotswap-agent-jackson-plugin/src/test/java/org/hotswap/agent/plugin/jackson/model/TestModel1.java
+++ b/plugin/hotswap-agent-jackson-plugin/src/test/java/org/hotswap/agent/plugin/jackson/model/TestModel1.java
@@ -1,0 +1,17 @@
+package org.hotswap.agent.plugin.jackson.model;
+
+/**
+ * @author liuzhengyang
+ * 2021/12/3
+ */
+public class TestModel1 {
+    private int age;
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+}

--- a/plugin/hotswap-agent-jackson-plugin/src/test/java/org/hotswap/agent/plugin/jackson/model/TestModel2.java
+++ b/plugin/hotswap-agent-jackson-plugin/src/test/java/org/hotswap/agent/plugin/jackson/model/TestModel2.java
@@ -1,0 +1,26 @@
+package org.hotswap.agent.plugin.jackson.model;
+
+/**
+ * @author liuzhengyang
+ * 2021/12/3
+ */
+public class TestModel2 {
+    private int age;
+    private String name;
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/plugin/hotswap-agent-jackson-plugin/src/test/resources/hotswap-agent.properties
+++ b/plugin/hotswap-agent-jackson-plugin/src/test/resources/hotswap-agent.properties
@@ -1,0 +1,3 @@
+# Logger level
+LOGGER=warning
+LOGGER.org.hotswap.agent.plugin.jackson=trace

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>plugin/hotswap-agent-undertow-plugin</module>
         <module>plugin/hotswap-agent-mybatis-plugin</module>
         <module>plugin/hotswap-agent-ibatis-plugin</module>
+        <module>plugin/hotswap-agent-jackson-plugin</module>
         <module>plugin/hotswap-agent-plugins</module>
         <module>hotswap-agent</module>
     </modules>


### PR DESCRIPTION
Jackson is used by spring mvc to convert model result to json string.
Jackson saves some type cache in internal to improve performance.
For example, there is `_rootDeserializers` cache field in `com.fasterxml.jackson.databind.ObjectMapper`. These caches cause new field can not be read from json or be written to json.
#409 