### PR TITLE
Handle missing declaredMethodCache in JdkPlugin

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/javassist/bytecode/ClassFile.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/javassist/bytecode/ClassFile.java
@@ -137,6 +137,42 @@ public final class ClassFile {
     public static final int JAVA_11 = 55;
 
     /**
+     * The major version number of class files
+     * for JDK 12.
+     */
+    public static final int JAVA_12 = 56;
+
+    /**
+     * The major version number of class files
+     * for JDK 13.
+     */
+    public static final int JAVA_13 = 57;
+
+    /**
+     * The major version number of class files
+     * for JDK 14.
+     */
+    public static final int JAVA_14 = 58;
+
+    /**
+     * The major version number of class files
+     * for JDK 15.
+     */
+    public static final int JAVA_15 = 59;
+
+    /**
+     * The major version number of class files
+     * for JDK 16.
+     */
+    public static final int JAVA_16 = 60;
+
+    /**
+     * The major version number of class files
+     * for JDK 17.
+     */
+    public static final int JAVA_17 = 61;
+
+    /**
      * The major version number of class files created
      * from scratch.  The default value is 47 (JDK 1.3).
      * It is 49 (JDK 1.5)
@@ -153,6 +189,18 @@ public final class ClassFile {
      * if the JVM supports <code>java.util.List.copyOf(Collection)</code>.
      * It is 55 (JDK 11)
      * if the JVM supports <code>java.util.Optional.isEmpty()</code>.
+     * It is 56 (JDK 12)
+     * if the JVM supports <code>com.sun.source.tree.CaseTree.getExpressions()</code>.
+     * It is 57 (JDK 13)
+     * if the JVM supports <code>com.sun.source.tree.YieldTree</code>.
+     * It is 58 (JDK 14)
+     * if the JVM supports <code>com.sun.management.OperatingSystemMXBean.getFreeMemorySize()</code>.
+     * It is 59 (JDK 15)
+     * if the JVM supports <code>java.security.interfaces.EdECPublicKey</code>.
+     * It is 60 (JDK 16)
+     * if the JVM supports <code>com.sun.source.tree.PatternTree</code>.
+     * It is 61 (JDK 17)
+     * if the JVM supports <code>java.util.random.RandomGenerator</code>.
      */
     public static final int MAJOR_VERSION;
 
@@ -173,8 +221,19 @@ public final class ClassFile {
             ver = JAVA_10;
             Class.forName("java.util.Optional").getMethod("isEmpty");
             ver = JAVA_11;
-        }
-        catch (Throwable t) {}
+            Class.forName("com.sun.source.tree.CaseTree").getMethod("getExpressions");
+            ver = JAVA_12;
+            Class.forName("com.sun.source.tree.YieldTree");
+            ver = JAVA_13;
+            Class.forName("com.sun.management.OperatingSystemMXBean").getMethod("getFreeMemorySize");
+            ver = JAVA_14;
+            Class.forName("java.security.interfaces.EdECPublicKey");
+            ver = JAVA_15;
+            Class.forName("com.sun.source.tree.PatternTree");
+            ver = JAVA_16;
+            Class.forName("java.util.random.RandomGenerator");
+            ver = JAVA_17;
+        } catch (Throwable t) {}
         MAJOR_VERSION = ver;
     }
 
@@ -187,7 +246,7 @@ public final class ClassFile {
 
     /**
      * Constructs a class file including no members.
-     * 
+     *
      * @param isInterface
      *            true if this is an interface. false if this is a class.
      * @param classname
@@ -333,7 +392,7 @@ public final class ClassFile {
 
     /**
      * Returns access flags.
-     * 
+     *
      * @see javassist.bytecode.AccessFlag
      */
     public int getAccessFlags() {
@@ -342,7 +401,7 @@ public final class ClassFile {
 
     /**
      * Changes access flags.
-     * 
+     *
      * @see javassist.bytecode.AccessFlag
      */
     public void setAccessFlags(int acc) {
@@ -354,11 +413,11 @@ public final class ClassFile {
 
     /**
      * Returns access and property flags of this nested class.
-     * This method returns -1 if the class is not a nested class. 
+     * This method returns -1 if the class is not a nested class.
      *
      * <p>The returned value is obtained from <code>inner_class_access_flags</code>
      * of the entry representing this nested class itself
-     * in <code>InnerClasses_attribute</code>. 
+     * in <code>InnerClasses_attribute</code>.
      */
     public int getInnerAccessFlags() {
         InnerClassesAttribute ica
@@ -410,7 +469,7 @@ public final class ClassFile {
 
     /**
      * Sets the super class.
-     * 
+     *
      * <p>
      * The new super class should inherit from the old super class.
      * This method modifies constructors so that they call constructors declared
@@ -433,13 +492,13 @@ public final class ClassFile {
 
     /**
      * Replaces all occurrences of a class name in the class file.
-     * 
+     *
      * <p>
      * If class X is substituted for class Y in the class file, X and Y must
      * have the same signature. If Y provides a method m(), X must provide it
      * even if X inherits m() from the super class. If this fact is not
      * guaranteed, the bytecode verifier may cause an error.
-     * 
+     *
      * @param oldname
      *            the replaced class name
      * @param newname
@@ -472,7 +531,7 @@ public final class ClassFile {
 
     /**
      * Replaces all occurrences of several class names in the class file.
-     * 
+     *
      * @param classnames
      *            specifies which class name is replaced with which new name.
      *            Class names must be described with the JVM-internal
@@ -503,7 +562,7 @@ public final class ClassFile {
 
     /**
      * Internal-use only.
-     * <code>CtClass.getRefClasses()</code> calls this method. 
+     * <code>CtClass.getRefClasses()</code> calls this method.
      */
     public final void getRefClasses(Map<String,String> classnames) {
         constPool.renameClass(classnames);
@@ -547,7 +606,7 @@ public final class ClassFile {
 
     /**
      * Sets the interfaces.
-     * 
+     *
      * @param nameList
      *            the names of the interfaces.
      */
@@ -581,7 +640,7 @@ public final class ClassFile {
 
     /**
      * Returns all the fields declared in the class.
-     * 
+     *
      * @return a list of <code>FieldInfo</code>.
      * @see FieldInfo
      */
@@ -620,7 +679,7 @@ public final class ClassFile {
 
     /**
      * Returns all the methods declared in the class.
-     * 
+     *
      * @return a list of <code>MethodInfo</code>.
      * @see MethodInfo
      */
@@ -631,7 +690,7 @@ public final class ClassFile {
     /**
      * Returns the method with the specified name. If there are multiple methods
      * with that name, this method returns one of them.
-     * 
+     *
      * @return null if no such method is found.
      */
     public MethodInfo getMethod(String name) {
@@ -720,7 +779,7 @@ public final class ClassFile {
      * the attribute is also added to the classs file represented by this
      * object.  If you remove an attribute from the list, it is also removed
      * from the class file.
-     * 
+     *
      * @return a list of <code>AttributeInfo</code> objects.
      * @see AttributeInfo
      */
@@ -735,7 +794,7 @@ public final class ClassFile {
      *
      * <p>An attribute name can be obtained by, for example,
      * {@link AnnotationsAttribute#visibleTag} or
-     * {@link AnnotationsAttribute#invisibleTag}. 
+     * {@link AnnotationsAttribute#invisibleTag}.
      * </p>
      *
      * @param name          attribute name
@@ -772,7 +831,7 @@ public final class ClassFile {
 
     /**
      * Returns the source file containing this class.
-     * 
+     *
      * @return null if this information is not available.
      */
     public String getSourceFile() {
@@ -864,7 +923,7 @@ public final class ClassFile {
 
     /**
      * Get the Major version.
-     * 
+     *
      * @return the major version
      */
     public int getMajorVersion() {
@@ -873,7 +932,7 @@ public final class ClassFile {
 
     /**
      * Set the major version.
-     * 
+     *
      * @param major
      *            the major version
      */
@@ -883,7 +942,7 @@ public final class ClassFile {
 
     /**
      * Get the minor version.
-     * 
+     *
      * @return the minor version
      */
     public int getMinorVersion() {
@@ -892,7 +951,7 @@ public final class ClassFile {
 
     /**
      * Set the minor version.
-     * 
+     *
      * @param minor
      *            the minor version
      */


### PR DESCRIPTION
The `java.beans.Introspector#declaredMethodCache` was removed as of JDK 13 (https://github.com/openjdk/jdk13u/commit/921b46738e0c3aaa2bf8c62e0accb0a5056190d3) which caused a reload exception in the `JdkPlugin`.