### PR TITLE
Weblogic plugin

### DIFF
--- a/plugin/hotswap-agent-plugins/pom.xml
+++ b/plugin/hotswap-agent-plugins/pom.xml
@@ -174,6 +174,13 @@
 
         <dependency>
             <groupId>org.hotswapagent</groupId>
+            <artifactId>hotswap-agent-weblogic-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.hotswapagent</groupId>
             <artifactId>hotswap-agent-vaadin-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugin/hotswap-agent-weblogic-plugin/README.md
+++ b/plugin/hotswap-agent-weblogic-plugin/README.md
@@ -1,0 +1,4 @@
+[Weblogic]()
+========================================
+
+experimental plugin for weblogic support based on [this comment](https://github.com/HotswapProjects/HotswapAgent/issues/164#issuecomment-701276011) by [Kladdkaka](https://github.com/Kladdkaka)

--- a/plugin/hotswap-agent-weblogic-plugin/README.md
+++ b/plugin/hotswap-agent-weblogic-plugin/README.md
@@ -1,4 +1,4 @@
-[Weblogic]()
+[Weblogic](https://www.oracle.com/java/weblogic/)
 ========================================
 
 experimental plugin for weblogic support based on [this comment](https://github.com/HotswapProjects/HotswapAgent/issues/164#issuecomment-701276011) by [Kladdkaka](https://github.com/Kladdkaka)

--- a/plugin/hotswap-agent-weblogic-plugin/README.md
+++ b/plugin/hotswap-agent-weblogic-plugin/README.md
@@ -2,3 +2,8 @@
 ========================================
 
 experimental plugin for weblogic support based on [this comment](https://github.com/HotswapProjects/HotswapAgent/issues/164#issuecomment-701276011) by [Kladdkaka](https://github.com/Kladdkaka)
+
+
+Configuration
+-------------
+Setup extraClasspath property in hotswap-agent.properties and put it inside WEB-INF/classes of deployed WAR.

--- a/plugin/hotswap-agent-weblogic-plugin/pom.xml
+++ b/plugin/hotswap-agent-weblogic-plugin/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.hotswapagent</groupId>
+        <artifactId>hotswap-agent-parent</artifactId>
+        <version>1.4.2-SNAPSHOT</version>
+        <relativePath>../../hotswap-agent-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hotswap-agent-weblogic-plugin</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hotswapagent</groupId>
+            <artifactId>hotswap-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugin/hotswap-agent-weblogic-plugin/src/main/java/org/hotswap/agent/plugin/weblogic/WeblogicPlugin.java
+++ b/plugin/hotswap-agent-weblogic-plugin/src/main/java/org/hotswap/agent/plugin/weblogic/WeblogicPlugin.java
@@ -69,7 +69,7 @@ public final class WeblogicPlugin {
         //@formatter:off
         ctClass.addMethod(CtNewMethod.make(
                 "public void $$ha$setExtraClassPath(java.net.URL[] extraClassPath) {" + 
-                        WeblogicPlugin.class.getName() + ".logMessage(\"okokok -> \" + extraClassPath[0].toString());" +
+                        WeblogicPlugin.class.getName() + ".logMessage(\"setExtraClassPath in=\" + extraClassPath[0].toString());" +
                         "try {" +
                             "weblogic.utils.classloaders.MultiClassFinder multiClassFinder = new weblogic.utils.classloaders.MultiClassFinder();" +
                             "for (int i=0; i<extraClassPath.length; i++) {" +
@@ -83,7 +83,7 @@ public final class WeblogicPlugin {
                                 "}" +
                             "}" +
                             "this.addClassFinderFirst(multiClassFinder);" +
-                            WeblogicPlugin.class.getName() + ".logMessage(\"classpathzlol -> \" + this.getClassPath());" +
+                            WeblogicPlugin.class.getName() + ".logMessage(\"setExtraClassPath result=\" + this.getClassPath());" +
                         "} catch (java.lang.Exception e) {" +
                             WeblogicPlugin.class.getName() + ".logException(e);" +
                         "}" +

--- a/plugin/hotswap-agent-weblogic-plugin/src/main/java/org/hotswap/agent/plugin/weblogic/WeblogicPlugin.java
+++ b/plugin/hotswap-agent-weblogic-plugin/src/main/java/org/hotswap/agent/plugin/weblogic/WeblogicPlugin.java
@@ -1,0 +1,110 @@
+// ModuleClassLoaderTransformerKt.java
+package org.hotswap.agent.plugin.weblogic;
+
+import org.hotswap.agent.annotation.Init;
+import org.hotswap.agent.annotation.OnClassLoadEvent;
+import org.hotswap.agent.annotation.Plugin;
+import org.hotswap.agent.javassist.CannotCompileException;
+import org.hotswap.agent.javassist.ClassPool;
+import org.hotswap.agent.javassist.CtClass;
+import org.hotswap.agent.javassist.CtNewMethod;
+import org.hotswap.agent.javassist.NotFoundException;
+import org.hotswap.agent.logging.AgentLogger;
+import org.hotswap.agent.util.classloader.HotswapAgentClassLoaderExt;
+import org.hotswap.agent.util.classloader.WatchResourcesClassLoader;
+
+@Plugin(name = "Weblogic",
+        description = "Weblogic plugin for dcevm",
+        testedVersions = {},
+        expectedVersions = {}
+)
+public final class WeblogicPlugin {
+
+    @Init
+    ClassLoader moduleClassLoader;
+
+    static protected AgentLogger LOGGER = AgentLogger.getLogger(WeblogicPlugin.class);
+
+    @OnClassLoadEvent(classNameRegexp = "weblogic.utils.classloaders.ChangeAwareClassLoader")
+    public static void transformChangeAwareClassLoader(ClassPool classPool, CtClass ctClass) throws NotFoundException, CannotCompileException {
+        LOGGER.info("transformChangeAwareClassLoader: {}", ctClass.getSimpleName());
+
+        String src = WeblogicPlugin.class.getName() + ".logMessage(\"ChangeAwareClassLoaderConstructor -> \" + $1.toString());";
+
+        ctClass.getDeclaredConstructor(new CtClass[] { classPool.get("weblogic.utils.classloaders.ClassFinder"), CtClass.booleanType, classPool.get("java.lang.ClassLoader") })
+               .insertBefore(src);
+
+    }
+
+    @OnClassLoadEvent(classNameRegexp = "weblogic.utils.classloaders.MultiClassFinder")
+    public static void transformMultiClassFinder(ClassPool classPool, CtClass ctClass) throws NotFoundException, CannotCompileException {
+        LOGGER.info("MultiClassFinder: {}", ctClass.getSimpleName());
+
+        String srcAddFinder = WeblogicPlugin.class.getName() + ".logMessage(\"MultiClassFinder#addFinder -> \" + $1.toString());";
+
+        ctClass.getDeclaredMethod("addFinder", new CtClass[] { classPool.get("weblogic.utils.classloaders.ClassFinder") }).insertBefore(srcAddFinder);
+
+        String srcAddFinderFirst = WeblogicPlugin.class.getName() + ".logMessage(\"MultiClassFinder#addFinderFirst -> \" + $1.toString());";
+
+        ctClass.getDeclaredMethod("addFinderFirst", new CtClass[] { classPool.get("weblogic.utils.classloaders.ClassFinder") }).insertBefore(srcAddFinderFirst);
+    }
+
+    @OnClassLoadEvent(classNameRegexp = "weblogic.utils.classloaders.CompositeWebAppFinder")
+    public static void transformCompositeWebAppFinder(ClassPool classPool, CtClass ctClass) throws NotFoundException, CannotCompileException {
+        LOGGER.info("CompositeWebAppFinder: {}", ctClass.getSimpleName());
+
+        String src = WeblogicPlugin.class.getName() + ".logMessage(\"CompositeWebAppFinder#addLibraryFinder -> \" + $1.toString());";
+
+        ctClass.getDeclaredMethod("addLibraryFinder", new CtClass[] { classPool.get("weblogic.utils.classloaders.ClassFinder") }).insertBefore(src);
+    }
+
+    @OnClassLoadEvent(classNameRegexp = "weblogic.utils.classloaders.GenericClassLoader")
+    public static void transformGenericClassLoader(ClassPool classPool, CtClass ctClass) throws NotFoundException, CannotCompileException {
+        LOGGER.info("transformGenericClassLoader: {}", ctClass.getSimpleName());
+
+        CtClass ctHaClassLoader = classPool.get(HotswapAgentClassLoaderExt.class.getName());
+        ctClass.addInterface(ctHaClassLoader);
+
+        // Implementation of HotswapAgentClassLoaderExt.setExtraClassPath(...)
+        //@formatter:off
+        ctClass.addMethod(CtNewMethod.make(
+                "public void $$ha$setExtraClassPath(java.net.URL[] extraClassPath) {" + 
+                        WeblogicPlugin.class.getName() + ".logMessage(\"okokok -> \" + extraClassPath[0].toString());" +
+                        "try {" +
+                            "weblogic.utils.classloaders.MultiClassFinder multiClassFinder = new weblogic.utils.classloaders.MultiClassFinder();" +
+                            "for (int i=0; i<extraClassPath.length; i++) {" +
+                                "try {" +
+                                    "java.net.URL url = extraClassPath[i];" +
+                                    "java.io.File root = new java.io.File(url.getPath());" +
+                                    "weblogic.utils.classloaders.IndexedDirectoryClassFinder indexedDirectoryClassFinder = new weblogic.utils.classloaders.IndexedDirectoryClassFinder(root);" +
+                                    "multiClassFinder.addFinder(indexedDirectoryClassFinder);" +
+                                "} catch (java.lang.Exception e) {" +
+                                    WeblogicPlugin.class.getName() + ".logException(e);" +
+                                "}" +
+                            "}" +
+                            "this.addClassFinderFirst(multiClassFinder);" +
+                            WeblogicPlugin.class.getName() + ".logMessage(\"classpathzlol -> \" + this.getClassPath());" +
+                        "} catch (java.lang.Exception e) {" +
+                            WeblogicPlugin.class.getName() + ".logException(e);" +
+                        "}" +
+                    "}", ctClass)
+        );
+        //@formatter:on
+
+        ctClass.addMethod(
+                CtNewMethod.make(
+                        "public void $$ha$setWatchResourceLoader(" + WatchResourcesClassLoader.class.getName() + " watchResourceLoader) { " +
+                        WeblogicPlugin.class.getName() + ".logMessage(\"WatchResourcesClassLoader -> \" + watchResourceLoader.toString());" +
+                        "}",
+                        ctClass
+                ));
+    }
+
+    public static void logMessage(String str){
+        LOGGER.info("logmessage: {}", str);
+    }
+
+    public static void logException(Exception e){
+        LOGGER.error("logException: {}", e);
+    }
+}

--- a/plugin/hotswap-agent-weblogic-plugin/src/main/java/org/hotswap/agent/plugin/weblogic/WeblogicPlugin.java
+++ b/plugin/hotswap-agent-weblogic-plugin/src/main/java/org/hotswap/agent/plugin/weblogic/WeblogicPlugin.java
@@ -15,8 +15,8 @@ import org.hotswap.agent.util.classloader.WatchResourcesClassLoader;
 
 @Plugin(name = "Weblogic",
         description = "Weblogic plugin for dcevm",
-        testedVersions = {},
-        expectedVersions = {}
+        testedVersions = {"12.2.1.4"},
+        expectedVersions = {"12c"}
 )
 public final class WeblogicPlugin {
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <module>plugin/hotswap-agent-ibatis-plugin</module>
         <module>plugin/hotswap-agent-jackson-plugin</module>
         <module>plugin/hotswap-agent-idea-plugin</module>
+        <module>plugin/hotswap-agent-weblogic-plugin</module>
         <module>plugin/hotswap-agent-plugins</module>
         <module>hotswap-agent</module>
     </modules>


### PR DESCRIPTION
A weblogic plugin based on comment https://github.com/HotswapProjects/HotswapAgent/issues/164#issuecomment-701276011 by https://github.com/Kladdkaka .

I have translated the original Kotlin code to Java and integrated with Hotswapagent project as a plugin.
It successfully reloads existing classes and adds new classes based extraClasspath.
Tested happy path with Weblogic 12c.

### Notes:
- put a hotswapagent.properties file in WEB-INF/classes of war deployed to Weblogic
- inside the file set the extraClasspath property
- I had trouble to find a good matching oraclejdk and dcevm pair to work correctly with weblogic on amd64. For now only these two seem to work OK
   - oraclejdk 1.8.0_05 + dcevm installer-light-jdk8u5.52.jar (25.5-b02-dcevmlight-58)
   - oraclejdk 1.8.0_25 + dcevm DCEVM-light-8u45-installer.jar (25.45-b02-dcevmlight-15
**NOTE: These versions are ancient and probably have lots of security vulnerabilities, use at your own risk.**
see also https://github.com/dcevm/dcevm/issues/101#issuecomment-1015627601 and https://stackoverflow.com/a/70759485/3484881<br>
It would be nice to have it running on a more recent JDK version, I will look into it. 