### PR TITLE
fix java.lang.AbstractMethodError in com.sun.proxy.$Proxy117 #429

### DIFF
--- a/plugin/hotswap-agent-proxy-plugin/src/main/java/org/hotswap/agent/plugin/proxy/ProxyPlugin.java
+++ b/plugin/hotswap-agent-proxy-plugin/src/main/java/org/hotswap/agent/plugin/proxy/ProxyPlugin.java
@@ -21,6 +21,7 @@ package org.hotswap.agent.plugin.proxy;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.hotswap.agent.annotation.LoadEvent;
 import org.hotswap.agent.annotation.OnClassLoadEvent;
@@ -56,7 +57,7 @@ public class ProxyPlugin {
      */
     public static boolean reloadFlag = false;
 
-    private static Set<String> proxyRedefiningMap = new HashSet<>();
+    private static Set<String> proxyRedefiningMap = ConcurrentHashMap.newKeySet();
 
     @OnClassLoadEvent(classNameRegexp = "(jdk.proxy\\d+.\\$Proxy.*)|(com.sun.proxy.\\$Proxy.*)", events = LoadEvent.REDEFINE, skipSynthetic = false)
     public static void transformJavaProxy(final Class<?> classBeingRedefined, final ClassLoader classLoader) {
@@ -96,6 +97,10 @@ public class ProxyPlugin {
 
         // TODO: can be single command if scheduler guarantees the keeping execution order in the order of redefinition
         PluginManager.getInstance().getScheduler().scheduleCommand(new ReloadJavaProxyCommand(classLoader, className, signatureMapOrig), 50);
+    }
+
+    public static void removeProxyDefiningClassName(String className) {
+        proxyRedefiningMap.remove(className);
     }
 
     @OnClassLoadEvent(classNameRegexp = ".*", events = LoadEvent.REDEFINE, skipSynthetic = false)


### PR DESCRIPTION
sometimes the jdk proxy class dont' realize the interface,
```java
java.lang.AbstractMethodError: com.test.HelloThriftService.hello(Ljava/lang/String;)Ljava/lang/String;
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_181]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_181]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_181]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_181]
```