### PR TITLE
Add errMsg when autoHotswap reload fail

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginManager.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginManager.java
@@ -293,6 +293,7 @@ public class PluginManager {
                 }
                 LOGGER.debug("... reloaded classes {} (autoHotswap)", Arrays.toString(classNames));
             } catch (Exception e) {
+                LOGGER.debug("... Fail to reload classes {} (autoHotswap), msg is {}", Arrays.toString(classNames), e);
                 throw new IllegalStateException("Unable to redefine classes", e);
             }
             reloadMap.clear();


### PR DESCRIPTION
Hello,
I want to push some modified classes (local project files) to serveral remote application servers to autoHotswap these classes. Thus I need to check the reload result by the hotswap-agent.log.  
Now it just throws the exception which can only be found in console output,  therefore I add the error log.

Is it useful to this projects?