### PR TITLE
Overrding all classloaders HA settings by -D params

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginConfiguration.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginConfiguration.java
@@ -88,6 +88,7 @@ public class PluginConfiguration {
             if (externalPropertiesFile != null) {
                 configurationURL = resourceNameToURL(externalPropertiesFile);
                 properties.load(configurationURL.openStream());
+                System.getProperties().forEach((key, value) -> properties.put(key, value));
                 return;
             }
 
@@ -162,8 +163,10 @@ public class PluginConfiguration {
                 containsPropertyFileDirectly = true;
             }
             try {
-                if (configurationURL != null)
+                if (configurationURL != null) {
                     properties.load(configurationURL.openStream());
+                    System.getProperties().forEach((key, value) -> properties.put(key, value));
+                }
             } catch (Exception e) {
                 LOGGER.error("Error while loading 'hotswap-agent.properties' from URL " + configurationURL, e);
             }


### PR DESCRIPTION
As comment in https://github.com/HotswapProjects/HotswapAgent/pull/366#issuecomment-1253261795 # 


I think when we want to override properties by -D , it need to take effect in all classloaders?

#366 