### PR TITLE
fix(sec): upgrade resteasy-jaxrs to 3.11.0.Final

### DIFF
--- a/plugin/hotswap-agent-resteasy-plugin/pom.xml
+++ b/plugin/hotswap-agent-resteasy-plugin/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <servlet-api.version>3.0.1</servlet-api.version>
-        <resteasy-jaxrs.version>3.0.14.Final</resteasy-jaxrs.version>
+        <resteasy-jaxrs.version>3.11.0.Final</resteasy-jaxrs.version>
     </properties>
 
     <dependencies>

--- a/plugin/hotswap-agent-resteasy-registry-plugin/pom.xml
+++ b/plugin/hotswap-agent-resteasy-registry-plugin/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <servlet-api.version>3.0.1</servlet-api.version>
-        <resteasy-jaxrs.version>3.0.14.Final</resteasy-jaxrs.version>
+        <resteasy-jaxrs.version>3.11.0.Final</resteasy-jaxrs.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Upgrade resteasy-jaxrs 3.0.14.Final to 3.11.0.Final for vulnerability fix:
         - [CVE-2017-7561](https://www.oscs1024.com/hd/MPS-2017-10357)
         - [CVE-2016-6347](https://www.oscs1024.com/hd/MPS-2017-4384)