### PR TITLE
fix(sec): upgrade org.springframework:spring-context to 5.3.19

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/pom.xml
+++ b/plugin/hotswap-agent-spring-plugin/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>hotswap-agent-spring-plugin</artifactId>
 
     <properties>
-        <org.springframework.version>5.3.18</org.springframework.version>
+        <org.springframework.version>5.3.19</org.springframework.version>
     </properties>
 
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-context 5.3.18
- [CVE-2022-22968](https://www.oscs1024.com/hd/CVE-2022-22968)


### What did I do？
Upgrade org.springframework:spring-context from 5.3.18 to 5.3.19 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS