### PR TITLE
fix(sec): upgrade io.undertow:undertow-core to 

### DIFF
--- a/plugin/hotswap-agent-undertow-plugin/pom.xml
+++ b/plugin/hotswap-agent-undertow-plugin/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
-            <version>2.2.17.Final</version>
+            <version>2.3.0.Alpha2</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.undertow:undertow-core 2.2.17.Final
- [CVE-2021-3597](https://www.oscs1024.com/hd/CVE-2021-3597)


### What did I do？
Upgrade io.undertow:undertow-core from 2.2.17.Final to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS

Signed-off-by:pen4<948453219@qq.com>