### PR TITLE
fix: make extraClasspath and watchResources work for tomcat7x

### DIFF
--- a/plugin/hotswap-agent-tomcat-plugin/src/main/java/org/hotswap/agent/plugin/tomcat/TomcatPlugin.java
+++ b/plugin/hotswap-agent-tomcat-plugin/src/main/java/org/hotswap/agent/plugin/tomcat/TomcatPlugin.java
@@ -101,19 +101,20 @@ public class TomcatPlugin {
 
             URL[] extraClasspath = pluginConfiguration.getExtraClasspath();
             if (extraClasspath.length > 0) {
-                if (majorVersion >= 7)
+                if (majorVersion > 7) {
                     watchResourcesClassLoader.initExtraPath(extraClasspath);
-                else
+                } else {
                     addRepositoriesAtStart(appClassLoader, extraClasspath, false);
-
+                }
             }
 
             URL[] watchResources = pluginConfiguration.getWatchResources();
             if (watchResources.length > 0) {
-                if (majorVersion >= 7)
+                if (majorVersion > 7) {
                     watchResourcesClassLoader.initWatchResources(watchResources, PluginManager.getInstance().getWatcher());
-                else
+                } else {
                     addRepositoriesAtStart(appClassLoader, watchResources, true);
+                }
             }
 
             // register special repo


### PR DESCRIPTION
There's a regression introduced to stop `extraClasspath` and `watchResources` work on apache tomcat 7. This change make it work again.