### PR TITLE
fix: extra class and resource won't work on tomcat 7.0.65 and after

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/util/ReflectionHelper.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/util/ReflectionHelper.java
@@ -214,4 +214,26 @@ public class ReflectionHelper {
             throw new IllegalArgumentException(String.format("Illegal access field %s.%s on %s", clazz.getName(), fieldName, target), e);
         }
     }
+
+    public static void set(Object target, String fieldName, Object value) {
+        Class<?> clazz = target.getClass();
+        while (clazz != null) {
+            try {
+                Field field = clazz.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.set(target, value);
+                break;
+            } catch (NoSuchFieldException e) {
+                // ignore
+            } catch (IllegalAccessException e) {
+                throw new IllegalArgumentException(String.format("Illegal access field %s.%s on %s", clazz.getName(),
+                        fieldName, target), e);
+            }
+            clazz = clazz.getSuperclass();
+        }
+
+        if (clazz == null) {
+            throw new IllegalArgumentException(String.format("No such field %s.%s on %s", target.getClass(), fieldName, target));
+        }
+    }
 }


### PR DESCRIPTION
Tomcat's WebappClassLoader has a big refactor since 7.0.65. This fix makes extra class and resource work on 7.0.65 and later too.

1. Make sure `repositories` and `files` are updated correctly, even they are moved into WebappClassLoaderBase.
2. In org.apache.catalina.loader.WebappClassLoaderBase#findResourceInternal(java.lang.String, java.lang.String, boolean), a fullPath is calculated:

```java
String fullPath = repositories[i] + path;
```

It leads to double '/' between repository and path. This double '/' works fine with tomcat's builtin DirContext but start to fail work with WatchResourcesClassLoader. This resource name must have to be normalized before passed it to WatchResourcesClassLoader.