### PR TITLE
support jsp update in spring boot

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginConfiguration.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginConfiguration.java
@@ -24,6 +24,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
@@ -95,77 +96,78 @@ public class PluginConfiguration {
         }
 
         if (parent == null) {
-            configurationURL = classLoader == null
-                    ? ClassLoader.getSystemResource(PLUGIN_CONFIGURATION)
-                    : classLoader.getResource(PLUGIN_CONFIGURATION);
+            // when parent plugin configuration is null, search for resources not known by parent classloader
+            // (defined in THIS classloader exclusively) this is necessary in case of parent classloader precedence
+            ClassLoader current = classLoader;
+            while (current != null) {
+                configurationURL = locateConfiguration(current, current.getParent());
+                if (configurationURL != null) {
+                    break;
+                }
+                current = current.getParent();
+            }
 
             try {
                 if (configurationURL != null) {
                     containsPropertyFileDirectly = true;
                     properties.load(configurationURL.openStream());
-
                 }
                 
                 // Add logging properties defined in jvm argument like -DLOGGER=warning
                 System.getProperties().forEach((key, value) -> properties.put(key, value));
-
             } catch (Exception e) {
                 LOGGER.error("Error while loading 'hotswap-agent.properties' from base URL " + configurationURL, e);
             }
-
         } else {
-            // search for resources not known by parent classloader (defined in THIS classloader exclusively)
-            // this is necessary in case of parent classloader precedence
-            try {
-                Enumeration<URL> urls = null;
-
-                if (classLoader != null) {
-                    urls = classLoader.getResources(PLUGIN_CONFIGURATION);
-                }
-
-                if (urls == null) {
-                    urls = ClassLoader.getSystemResources(PLUGIN_CONFIGURATION);
-                }
-
-                while (urls.hasMoreElements()) {
-                    URL url = urls.nextElement();
-
-                    boolean found = false;
-
-                    ClassLoader parentClassLoader = parent.getClassLoader();
-                    Enumeration<URL> parentUrls = parentClassLoader == null
-                            ? ClassLoader.getSystemResources(PLUGIN_CONFIGURATION)
-                            : parentClassLoader.getResources(PLUGIN_CONFIGURATION);
-
-                    while (parentUrls.hasMoreElements()) {
-                        if (url.equals(parentUrls.nextElement()))
-                            found = true;
-                    }
-
-                    if (!found) {
-                        configurationURL = url;
-                        break;
-                    }
-                }
-            } catch (IOException e) {
-                LOGGER.error("Error while loading 'hotswap-agent.properties' from URL " + configurationURL, e);
-            }
-
+            configurationURL = locateConfiguration(classLoader, parent.getClassLoader());
             if (configurationURL == null) {
                 configurationURL = parent.configurationURL;
                 LOGGER.debug("Classloader does not contain 'hotswap-agent.properties', using parent file '{}'"
                         , parent.configurationURL);
-
             } else {
                 LOGGER.debug("Classloader contains 'hotswap-agent.properties' at location '{}'", configurationURL);
                 containsPropertyFileDirectly = true;
             }
+
             try {
-                if (configurationURL != null)
+                if (configurationURL != null) {
                     properties.load(configurationURL.openStream());
+                }
             } catch (Exception e) {
                 LOGGER.error("Error while loading 'hotswap-agent.properties' from URL " + configurationURL, e);
             }
+        }
+    }
+
+    private URL locateConfiguration(ClassLoader classLoader, ClassLoader parentClassLoader) {
+        Enumeration<URL> urls = getConfigurationURLs(classLoader);
+        while (urls.hasMoreElements()) {
+            URL url = urls.nextElement();
+            boolean found = false;
+            Enumeration<URL> parentUrls = getConfigurationURLs(parentClassLoader);
+            while (parentUrls.hasMoreElements()) {
+                if (url.equals(parentUrls.nextElement())) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return url;
+            }
+        }
+
+        return null;
+    }
+
+    private Enumeration<URL> getConfigurationURLs(ClassLoader classLoader) {
+        try {
+            if (classLoader == null) {
+                classLoader = ClassLoader.getSystemClassLoader();
+            }
+            return classLoader.getResources(PLUGIN_CONFIGURATION);
+        } catch (IOException e) {
+            LOGGER.error("Error while finding 'hotswap-agent.properties'", e);
+            return Collections.emptyEnumeration();
         }
     }
 

--- a/plugin/hotswap-agent-tomcat-plugin/src/main/java/org/hotswap/agent/plugin/tomcat/WebappLoaderTransformer.java
+++ b/plugin/hotswap-agent-tomcat-plugin/src/main/java/org/hotswap/agent/plugin/tomcat/WebappLoaderTransformer.java
@@ -241,4 +241,19 @@ public class WebappLoaderTransformer {
         }
     }
 
+    /**
+     * Make sure development mode is true so that JSP compilation will always be triggered, especially for embedded
+     * Tomcat running in Spring Boot.
+     */
+    @OnClassLoadEvent(classNameRegexp = "org.apache.catalina.core.StandardWrapper")
+    public static void patchStandardWrapper(ClassPool classPool, CtClass ctClass) {
+        try {
+            ctClass.getDeclaredMethod("getInitParameter", new CtClass[]{classPool.get("java.lang.String")}).insertBefore(
+                    "if ($1.equals(\"development\")) return \"true\";"
+            );
+        } catch (CannotCompileException | NotFoundException e) {
+            LOGGER.debug("org.apache.catalina.core.StandardWrapper does not contain getInitParameter method.");
+        }
+    }
+
 }


### PR DESCRIPTION
In a spring boot web application, TomcatPlugin cannot locate the 'hotswap-agent.properties' packaged in WEB-INF/classes. This change can make both SpringPlugin and TomcatPlugin locate the right properties file instead of the one packaged in hotswapagent.jar. 

```properties
extraClasspath=/Users/iluo/tmp/tutorial/spring-mvc-basic-1/target/classes
watchResources=/Users/iluo/tmp/tutorial/spring-mvc-basic-1/src/main/resources
webappDir=/Users/iluo/tmp/tutorial/spring-mvc-basic-1/src/main/webapp
LOGGER=debug
```

This change also patches org.apache.catalina.core.StandardWrapper so that Tomcat always runs in development mode and JSP compilation works in development mode too. It is necessary since Spring Boot configures embedded tomcat in production mode.

To reproduce the issue, write a simple spring boot web application, put jsp files under src/main/webapp, and package the application in war format.

I also notice the current 'org.hotswap.agent.config.PluginConfiguration#loadConfigurationFile' implementation looks problematic. The current implementation is: 

1. when parent plugin == null, look for properties with the plugin's classloader, and I change its logic to look for properties file by climbing up the classloader hierarchy.
2. when parent plugin != null, find out the distinct property file exisitng in the plugin classloader but not in the parent classloader.


I am not sure what more accurate behavior this method should be.


