### PR TITLE
Placeholder support

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/run-tests.sh
+++ b/plugin/hotswap-agent-spring-plugin/run-tests.sh
@@ -15,6 +15,8 @@ function test {
 
 # test following Spring versions
 
+# test 6.0.10
+
 # test 5.3.0
 # test 5.3.1
 # test 5.3.2
@@ -34,8 +36,8 @@ function test {
 # test 5.3.16
 # test 5.3.17
 
-# 5.3.18 is lowest not vulnerable version(2022.04.23)
-test 5.3.18
+# 5.3.28 is lowest not vulnerable version(2023.7.05)
+test 5.3.28
 
 # test 5.2.0.RELEASE
 # test 5.2.1.RELEASE

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/ResetBeanFactoryCaches.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/ResetBeanFactoryCaches.java
@@ -1,0 +1,31 @@
+package org.hotswap.agent.plugin.spring;
+
+import org.hotswap.agent.logging.AgentLogger;
+import org.springframework.beans.factory.support.AbstractBeanFactory;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.util.StringValueResolver;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+public class ResetBeanFactoryCaches {
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(ResetBeanFactoryCaches.class);
+
+    public static void reset(DefaultListableBeanFactory beanFactory) {
+        resetEmbeddedValueResolvers(beanFactory);
+    }
+
+    private static void resetEmbeddedValueResolvers(DefaultListableBeanFactory beanFactory) {
+        try {
+            Field field = AbstractBeanFactory.class.getDeclaredField("embeddedValueResolvers");
+            field.setAccessible(true);
+            List<StringValueResolver> embeddedValueResolvers = (List<StringValueResolver>) field.get(beanFactory);
+            if (embeddedValueResolvers != null && !embeddedValueResolvers.isEmpty()) {
+                embeddedValueResolvers.clear();
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/ResetBeanFactoryCaches.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/ResetBeanFactoryCaches.java
@@ -1,4 +1,22 @@
 package org.hotswap.agent.plugin.spring;
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
 
 import org.hotswap.agent.logging.AgentLogger;
 import org.springframework.beans.factory.support.AbstractBeanFactory;
@@ -24,7 +42,7 @@ public class ResetBeanFactoryCaches {
                 embeddedValueResolvers.clear();
             }
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
+            LOGGER.error("Error resetting embeddedValueResolvers for bean factory {}", e, beanFactory);
         }
 
     }

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/SpringPlugin.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/SpringPlugin.java
@@ -18,15 +18,6 @@
  */
 package org.hotswap.agent.plugin.spring;
 
-import java.io.IOException;
-import java.lang.instrument.IllegalClassFormatException;
-import java.net.URL;
-import java.security.ProtectionDomain;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-
 import org.hotswap.agent.annotation.FileEvent;
 import org.hotswap.agent.annotation.Init;
 import org.hotswap.agent.annotation.OnClassLoadEvent;
@@ -41,15 +32,28 @@ import org.hotswap.agent.javassist.CtMethod;
 import org.hotswap.agent.javassist.NotFoundException;
 import org.hotswap.agent.logging.AgentLogger;
 import org.hotswap.agent.plugin.spring.getbean.ProxyReplacerTransformer;
-import org.hotswap.agent.plugin.spring.scanner.*;
+import org.hotswap.agent.plugin.spring.scanner.ClassPathBeanDefinitionScannerTransformer;
+import org.hotswap.agent.plugin.spring.scanner.ClassPathBeanRefreshCommand;
+import org.hotswap.agent.plugin.spring.scanner.PropertiesRefreshCommand;
+import org.hotswap.agent.plugin.spring.scanner.XmlBeanDefinitionScannerTransformer;
+import org.hotswap.agent.plugin.spring.scanner.XmlBeanRefreshCommand;
+import org.hotswap.agent.util.HaClassFileTransformer;
 import org.hotswap.agent.util.HotswapTransformer;
 import org.hotswap.agent.util.IOUtils;
 import org.hotswap.agent.util.PluginManagerInvoker;
-import org.hotswap.agent.util.HaClassFileTransformer;
 import org.hotswap.agent.util.classloader.ClassLoaderHelper;
 import org.hotswap.agent.watch.WatchEventListener;
 import org.hotswap.agent.watch.WatchFileEvent;
 import org.hotswap.agent.watch.Watcher;
+
+import java.io.IOException;
+import java.lang.instrument.IllegalClassFormatException;
+import java.net.URL;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
 
 /**
  * Spring plugin.

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/PropertiesRefreshCommand.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/PropertiesRefreshCommand.java
@@ -1,0 +1,33 @@
+package org.hotswap.agent.plugin.spring.scanner;
+
+import org.hotswap.agent.command.MergeableCommand;
+import org.hotswap.agent.logging.AgentLogger;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+
+public class PropertiesRefreshCommand extends MergeableCommand {
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(PropertiesRefreshCommand.class);
+
+    private final URL url;
+    private final ClassLoader appClassLoader;
+
+    public PropertiesRefreshCommand(ClassLoader classLoader, URL url) {
+        this.url = url;
+        this.appClassLoader = classLoader;
+    }
+
+    @Override
+    public void executeCommand() {
+        try {
+            Class<?> clazz = Class.forName("org.hotswap.agent.plugin.spring.scanner.XmlBeanDefinitionScannerAgent", true, appClassLoader);
+            Method method = clazz.getDeclaredMethod("reloadProperty", URL.class);
+            method.invoke(null, url);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            LOGGER.error("Error refreshing property file {} in classLoader {}", e, this.url, appClassLoader);
+        }
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/PropertiesRefreshCommand.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/PropertiesRefreshCommand.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
 package org.hotswap.agent.plugin.spring.scanner;
 
 import org.hotswap.agent.command.MergeableCommand;

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/XmlBeanDefinitionScannerTransformer.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/XmlBeanDefinitionScannerTransformer.java
@@ -24,7 +24,7 @@ import org.hotswap.agent.logging.AgentLogger;
 
 /**
  * Hook into classpath scanner process to register basicPackage of scanned classes.
- *
+ * <p>
  * Catch changes on component-scan configuration such as (see tests):
  * <pre>&lt;context:component-scan base-package="org.hotswap.agent.plugin.spring.testBeans"/&gt;</pre>
  */
@@ -42,10 +42,10 @@ public class XmlBeanDefinitionScannerTransformer {
     @OnClassLoadEvent(classNameRegexp = "org.springframework.beans.factory.xml.XmlBeanDefinitionReader")
     public static void transform(CtClass clazz, ClassPool classPool) throws NotFoundException, CannotCompileException {
 
-        CtMethod method = clazz.getDeclaredMethod("loadBeanDefinitions", new CtClass[]{classPool.get("org.springframework.core.io.support.EncodedResource")});
-        method.insertAfter("org.hotswap.agent.plugin.spring.scanner.XmlBeanDefinitionScannerAgent." +
-                "registerXmlBeanDefinitionScannerAgent(this, $1.getResource());");
-
+        CtMethod method = clazz.getDeclaredMethod("registerBeanDefinitions", new CtClass[]{
+                classPool.get("org.w3c.dom.Document"),
+                classPool.get("org.springframework.core.io.Resource")});
+        method.insertBefore("org.hotswap.agent.plugin.spring.scanner.XmlBeanDefinitionScannerAgent.registerXmlBeanDefinitionScannerAgent(this, $2);");
         LOGGER.debug("Class 'org.springframework.beans.factory.xml.XmlBeanDefinitionReader' patched with xmlReader registration.");
     }
 }

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/placeholder/Item1.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/placeholder/Item1.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.xml.placeholder;
+
+public class Item1 {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/placeholder/Item2.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/placeholder/Item2.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.xml.placeholder;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public class Item2 {
+    @Value("${item.name}")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/placeholder/PlaceholderTest.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/placeholder/PlaceholderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.xml.placeholder;
+
+import org.hotswap.agent.plugin.spring.scanner.XmlBeanDefinitionScannerAgent;
+import org.hotswap.agent.util.test.WaitHelper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:placeholderContext.xml"})
+public class PlaceholderTest {
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private static final Resource propertyFile = new ClassPathResource("item.properties");
+    private static final Resource changedPropertyFile = new ClassPathResource("itemChanged.properties");
+
+    @Test
+    public void swapPropertyTest() throws Exception {
+        Assert.assertEquals("item-name", applicationContext.getBean("item1", Item1.class).getName());
+        Assert.assertEquals("item-name", applicationContext.getBean("item2", Item2.class).getName());
+
+        XmlBeanDefinitionScannerAgent.reloadFlag = true;
+        modifyPropertyFile();
+
+        Assert.assertTrue(WaitHelper.waitForCommand(new WaitHelper.Command() {
+            @Override
+            public boolean result() throws Exception {
+                return !XmlBeanDefinitionScannerAgent.reloadFlag;
+            }
+        }, 5000));
+
+        Assert.assertEquals("ITEM-NAME", applicationContext.getBean("item1", Item1.class).getName());
+        Assert.assertEquals("ITEM-NAME", applicationContext.getBean("item2", Item2.class).getName());
+    }
+
+
+    private void modifyPropertyFile() throws Exception {
+        Files.copy(changedPropertyFile.getFile().toPath(), propertyFile.getFile().toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/resources/item.properties
+++ b/plugin/hotswap-agent-spring-plugin/src/test/resources/item.properties
@@ -1,0 +1,1 @@
+item.name=item-name

--- a/plugin/hotswap-agent-spring-plugin/src/test/resources/itemChanged.properties
+++ b/plugin/hotswap-agent-spring-plugin/src/test/resources/itemChanged.properties
@@ -1,0 +1,1 @@
+item.name=ITEM-NAME

--- a/plugin/hotswap-agent-spring-plugin/src/test/resources/placeholderContext.xml
+++ b/plugin/hotswap-agent-spring-plugin/src/test/resources/placeholderContext.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
+    <context:annotation-config/>
+
+    <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
+        <property name="location" value="classpath:item.properties"/>
+    </bean>
+
+    <bean id="item1" class="org.hotswap.agent.plugin.spring.xml.placeholder.Item1">
+        <property name="name" value="${item.name}"/>
+    </bean>
+
+    <bean id="item2" class="org.hotswap.agent.plugin.spring.xml.placeholder.Item2"/>
+</beans>


### PR DESCRIPTION
Given the spring XML configuration, and Spring beans 'Store' and 'Item' below:


ioc-context-by-type.xml

```xml
<?xml version="1.0" encoding="UTF-8"?>
<beans xmlns="http://www.springframework.org/schema/beans"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://www.springframework.org/schema/beans
        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

    <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
        <property name="location" value="classpath:item.properties"/>
    </bean>

    <bean id="item" class="com.baeldung.store.ItemImpl1">
        <property name="name" value="${item.name}"/>
    </bean>

    <bean id="xml-store-by-autowire-type" class="com.baeldung.store.Store" autowire="byType">
    </bean>

</beans>
```

item.properties

```properties
item.name=item-one
```

Store.java

```java
public class Store {
    
    @Autowired
    private Item item;
    
    public Store() {}
    
    public Store(Item item) {
        this.item = item;
    }

    public Item getItem() {
        return item;
    }

    public void setItem(Item item) {
        this.item = item;
    }
}
```

Item.java

```java
public interface Item {
    default String getName() {
        return this.getClass().getName();
    }
}
```

ItemImpl1.java

```java
public class ItemImpl1 implements Item {
    private String name;

    @Override
    public String getName() {
        return name;
    }

    public void setName(String name) {
        this.name = name;
    }
}
```

App.java

```java
public class App {
    public static void main(String[] args) throws InterruptedException {
        ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("classpath:/ioc-context-by-type.xml");

        for (int i = 0; i < 1000; i++) {
            try {
                Item item = ctx.getBean(Store.class).getItem();
                System.out.println(">>> " +
                        item.getClass().getName() + ", " +
                        item.getName());

                Map<String, PropertyResourceConfigurer> configurers = ctx.getBeansOfType(PropertyResourceConfigurer.class);
                for (String key : configurers.keySet()) {
                    System.out.println(">>> " + key + " : " + configurers.get(key));
                }
                Thread.sleep(5000);
            } catch (Exception e) {
                e.printStackTrace();
            }
        }
    }
}
```

The proposed change supports:
1. User can edit item.properties and its values can be refreshed automatically now.
2. Avoid of creating repeated instances for un-named Spring bean when refresh happens, in this case, it is PropertySourcesPlaceholderConfigurer. Without this change, everytime when refresh happens, one new bean instance will be created with the following sequence:
   * org.springframework.context.support.PropertySourcesPlaceholderConfigurer#0
   * org.springframework.context.support.PropertySourcesPlaceholderConfigurer#1
   * org.springframework.context.support.PropertySourcesPlaceholderConfigurer#2
   * and so on.

