### PR TITLE
enhance exclude classloader

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginManager.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/config/PluginManager.java
@@ -188,8 +188,9 @@ public class PluginManager {
             }
 
             // create new configuration for the classloader
-            PluginConfiguration configuration = new PluginConfiguration(getPluginConfiguration(getClass().getClassLoader()), classLoader);
-            classLoaderConfigurations.put(classLoader, configuration);
+            PluginConfiguration pluginConfiguration = new PluginConfiguration(getPluginConfiguration(getClass().getClassLoader()), classLoader, false);
+            classLoaderConfigurations.put(classLoader, pluginConfiguration);
+            pluginConfiguration.init();
         }
 
         // call listeners

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/util/HotswapTransformer.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/util/HotswapTransformer.java
@@ -88,6 +88,10 @@ public class HotswapTransformer implements ClassFileTransformer {
         this.excludedClassLoaderPatterns = excludedClassLoaderPatterns;
     }
 
+    public List<Pattern> getExcludedClassLoaderPatterns() {
+        return excludedClassLoaderPatterns;
+    }
+
     /**
      * Register a transformer for a regexp matching class names.
      * Used by {@link org.hotswap.agent.annotation.OnClassLoadEvent} annotation respective


### PR DESCRIPTION
when we configure excludedClassLoaderPatterns in hotswap-agent.properteis, the extraClasspath is still prepended to URLClassPath of URLClassLoader