### PR TITLE
support reloading when individual bean class is changed for xml based spring app

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/placeholder/Item2WithoutValue.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/placeholder/Item2WithoutValue.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.xml.placeholder;
+
+public class Item2WithoutValue {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
This change is mainly to make refreshing work when individual bean class is changed for XML based Spring application. Without it, refreshing will not be detected by SpringPlugin therefore hotswap will not happen at all.

In this change, I also refactor all commands (MergeableCommand's impls) in this plugin to make the implementation better.