### PR TITLE
make <context:annotation-config/> able to hotswap

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/ResetBeanFactoryCaches.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/ResetBeanFactoryCaches.java
@@ -55,6 +55,21 @@ public class ResetBeanFactoryCaches {
     }
 
     private static void resetBeanPostProcessors(DefaultListableBeanFactory beanFactory) {
+        resetBeanPostProcessorList(beanFactory);
+        resetBeanPostProcessorCache(beanFactory);
+    }
+
+    private static void resetBeanPostProcessorCache(DefaultListableBeanFactory beanFactory) {
+        try {
+            Field field = AbstractBeanFactory.class.getDeclaredField("beanPostProcessorCache");
+            field.setAccessible(true);
+            field.set(beanFactory, null);
+        } catch (Throwable t) {
+            LOGGER.error("Error resetting beanPostProcessors for bean factory {}", t, beanFactory);
+        }
+    }
+
+    private static void resetBeanPostProcessorList(DefaultListableBeanFactory beanFactory) {
         String[] postProcessorNames = beanFactory.getBeanNamesForType(BeanPostProcessor.class, true, false);
         Set<String> postProcessorClasses = new HashSet<>();
         for (String postProcessorName : postProcessorNames) {
@@ -68,19 +83,6 @@ public class ResetBeanFactoryCaches {
             }
         }
 
-
-        removePostProcessor(beanFactory, postProcessorClasses);
-
-        try {
-            Field field = AbstractBeanFactory.class.getDeclaredField("beanPostProcessorCache");
-            field.setAccessible(true);
-            field.set(beanFactory, null);
-        } catch (Throwable t) {
-            LOGGER.error("Error resetting beanPostProcessors for bean factory {}", t, beanFactory);
-        }
-    }
-
-    private static void removePostProcessor(DefaultListableBeanFactory beanFactory, Set<String> postProcessorClasses) {
         try {
             Field field = AbstractBeanFactory.class.getDeclaredField("beanPostProcessors");
             field.setAccessible(true);

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/ResetBeanFactoryPostProcessorCaches.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/ResetBeanFactoryPostProcessorCaches.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring;
+
+import org.hotswap.agent.logging.AgentLogger;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.annotation.ConfigurationClassPostProcessor;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+
+public class ResetBeanFactoryPostProcessorCaches {
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(ResetBeanFactoryPostProcessorCaches.class);
+
+    public static void reset(DefaultListableBeanFactory beanFactory) {
+        resetConfigurationClassPostProcessorCache(beanFactory);
+    }
+
+    public static void resetConfigurationClassPostProcessorCache(DefaultListableBeanFactory beanFactory) {
+        try {
+            int factoryId = System.identityHashCode(beanFactory);
+            ConfigurationClassPostProcessor ccpp = beanFactory.getBean(ConfigurationClassPostProcessor.class);
+            Field field = ConfigurationClassPostProcessor.class.getDeclaredField("factoriesPostProcessed");
+            field.setAccessible(true);
+            Set<Integer> factoriesPostProcessed = (Set<Integer>) field.get(ccpp);
+            factoriesPostProcessed.remove(factoryId);
+
+            field = ConfigurationClassPostProcessor.class.getDeclaredField("registriesPostProcessed");
+            field.setAccessible(true);
+            Set<Integer> registriesPostProcessed = (Set<Integer>) field.get(ccpp);
+            registriesPostProcessed.remove(factoryId);
+        } catch (Exception e) {
+            LOGGER.debug("ConfigurationClassPostProcessor bean doesn't present");
+        }
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/XmlBeanDefinitionScannerAgent.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/XmlBeanDefinitionScannerAgent.java
@@ -267,14 +267,7 @@ public class XmlBeanDefinitionScannerAgent {
         ResetBeanPostProcessorCaches.reset(factory);
         ResetBeanFactoryPostProcessorCaches.reset(factory);
         ProxyReplacer.clearAllProxies();
-
-        LOGGER.debug("Remove all beans defined in the XML file {} before reloading it", url.getPath());
-        for (String beanName : beansRegistered.keySet()) {
-            factory.removeBeanDefinition(beanName);
-        }
-
-        beansRegistered.clear();
-
+        removeRegisteredBeanDefinitions(factory);
         ResetBeanFactoryCaches.reset(factory);
 
         LOGGER.info("Reloading XML file: " + url);
@@ -288,6 +281,15 @@ public class XmlBeanDefinitionScannerAgent {
         reloadFlag = false;
     }
 
+    private void removeRegisteredBeanDefinitions(DefaultListableBeanFactory factory) {
+        LOGGER.debug("Remove all beans defined in the XML file {} before reloading it", url.getPath());
+        for (String beanName : beansRegistered.keySet()) {
+            factory.removeBeanDefinition(beanName);
+        }
+
+        beansRegistered.clear();
+    }
+
     private static void addBeanPostProcessors(DefaultListableBeanFactory factory) {
         String[] names = factory.getBeanNamesForType(BeanPostProcessor.class, true, false);
         for (String name : names) {
@@ -296,8 +298,6 @@ public class XmlBeanDefinitionScannerAgent {
             LOGGER.debug("Add BeanPostProcessor {}", name);
         }
     }
-
-
 
     /**
      * convert src/main/resources/xxx.xml and classes/xxx.xml to xxx.xml

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/placeholder/AnnotationConfigTest.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/placeholder/AnnotationConfigTest.java
@@ -1,0 +1,43 @@
+package org.hotswap.agent.plugin.spring.xml.placeholder;
+
+import org.hotswap.agent.plugin.spring.scanner.XmlBeanDefinitionScannerAgent;
+import org.hotswap.agent.util.test.WaitHelper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class AnnotationConfigTest {
+    private static final Resource xmlFile = new ClassPathResource("placeholderContext.xml");
+    private static final Resource xmlFileWithoutAnnotationConfig = new ClassPathResource("placeholderContextWithoutAnnotationConfig.xml");
+
+    @Test
+    public void swapXmlTest() throws Exception {
+        ApplicationContext applicationContext = new ClassPathXmlApplicationContext("classpath:placeholderContextWithoutAnnotationConfig.xml");
+        assertNull(applicationContext.getBean("item2", Item2.class).getName());
+
+        XmlBeanDefinitionScannerAgent.reloadFlag = true;
+        Files.copy(xmlFile.getFile().toPath(), xmlFileWithoutAnnotationConfig.getFile().toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+        Assert.assertTrue(WaitHelper.waitForCommand(new WaitHelper.Command() {
+            @Override
+            public boolean result() throws Exception {
+                return !XmlBeanDefinitionScannerAgent.reloadFlag;
+            }
+        }, 5000));
+
+        assertNotNull(applicationContext.getBean("item2", Item2.class).getName());
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/resources/placeholderContextWithoutAnnotationConfig.xml
+++ b/plugin/hotswap-agent-spring-plugin/src/test/resources/placeholderContextWithoutAnnotationConfig.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+    <bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
+        <property name="location" value="classpath:item.properties"/>
+    </bean>
+
+    <bean id="item1" class="org.hotswap.agent.plugin.spring.xml.placeholder.Item1">
+        <property name="name" value="${item.name}"/>
+    </bean>
+
+    <bean id="item2" class="org.hotswap.agent.plugin.spring.xml.placeholder.Item2"/>
+</beans>


### PR DESCRIPTION
Currently HotswapAgent's spring plugin cannot hotswap when `<context:annotation-config/>` is switched on and off. For example, given the XML configuration file below:

```xml
<beans>
    <bean id="item" class="com.baeldung.store.ItemImpl2"/>
</beans>
```

when `<context:annotation-config/>` is added:

```xml
<beans>
    <context:annotation-config/>
    <bean id="item" class="com.baeldung.store.ItemImpl2"/>
</beans>
```

The annotations defined in ItemImpl2 should be honored but they are not, for example: `@Value` will not be injected when annotation config is turned on. This proposed change make `<context:annotation-config/>` can be able to hotswap as expected 