### PR TITLE
Spring @Configuration  support

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/util/HotswapTransformer.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/util/HotswapTransformer.java
@@ -116,7 +116,10 @@ public class HotswapTransformer implements ClassFileTransformer {
             transformerRecord.pattern = Pattern.compile(normalizeRegexp);
             transformersMap.put(normalizeRegexp, transformerRecord);
         }
-        transformerRecord.transformerList.add(transformer);
+
+        if (!transformerRecord.transformerList.contains(transformer)) {
+            transformerRecord.transformerList.add(transformer);
+        }
 
         // register classloader association to allow classloader unregistration
         if (classLoader != null) {

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/util/ReflectionHelper.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/util/ReflectionHelper.java
@@ -194,6 +194,29 @@ public class ReflectionHelper {
     }
 
     /**
+     * Convenience wrapper to reflection field access API. Get field value and
+     * swallow exceptions. Use this method if you have multiple framework support
+     * and the field may not exist in current version.
+     *
+     * @param target    object to get field value (or null for static methods)
+     * @param className class name
+     * @param cl        class loader to load the target class
+     * @param fieldName field name
+     * @return field value or null if an exception
+     */
+    public static Object getNoException(Object target, String className, ClassLoader cl, String fieldName) {
+        Class<?> clazz;
+        try {
+            clazz = cl.loadClass(className);
+        } catch (ClassNotFoundException e) {
+            LOGGER.trace("Class {} not found", e, className);
+            return null;
+        }
+
+        return getNoException(target, clazz, fieldName);
+    }
+
+    /**
      * Convenience wrapper to reflection field access API. Set field value and hide
      * checked exceptions.
      *

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/AbstractNIO2Watcher.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/AbstractNIO2Watcher.java
@@ -123,7 +123,10 @@ public abstract class AbstractNIO2Watcher implements Watcher {
             list = new ArrayList<WatchEventListener>();
             listeners.put(Paths.get(pathPrefix), list);
         }
-        list.add(listener);
+
+        if (!list.contains(listener)) {
+            list.add(listener);
+        }
 
         if (classLoader != null) {
             classLoaderListeners.put(listener, classLoader);

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/processor/ConfigurationClassPostProcessorAgent.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/processor/ConfigurationClassPostProcessorAgent.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.processor;
+
+import org.hotswap.agent.logging.AgentLogger;
+import org.hotswap.agent.plugin.spring.utils.RegistryUtils;
+import org.hotswap.agent.util.ReflectionHelper;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.annotation.ConfigurationClassPostProcessor;
+import org.springframework.core.Conventions;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+public class ConfigurationClassPostProcessorAgent {
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(ConfigurationClassPostProcessorAgent.class);
+
+    private static final ConfigurationClassPostProcessorAgent INSTANCE = new ConfigurationClassPostProcessorAgent();
+
+    private static final String CONFIGURATION_CLASS_ATTRIBUTE =
+            Conventions.getQualifiedAttributeName(ConfigurationClassPostProcessor.class, "configurationClass");
+
+    private ConfigurationClassPostProcessor processor;
+
+
+    public static ConfigurationClassPostProcessorAgent getInstance() {
+        return INSTANCE;
+    }
+
+    private ConfigurationClassPostProcessorAgent() {
+    }
+
+    public void setProcessor(ConfigurationClassPostProcessor processor) {
+        LOGGER.debug("ConfigurationClassPostProcessorAgent.setProcessor({})", processor);
+        this.processor = processor;
+    }
+
+    public ConfigurationClassPostProcessor getProcessor() {
+        return processor;
+    }
+
+    public void postProcess(BeanDefinitionRegistry registry, String beanName) {
+        if (processor == null) {
+            return;
+        }
+
+        resetCachingMetadataReaderFactoryCache();
+        resetBeanNameCache();
+        resetBeanFactoryCache(registry);
+        removeBeanAttribute(registry, beanName);
+
+        processor.processConfigBeanDefinitions(registry);
+    }
+
+    private MetadataReaderFactory getMetadataReaderFactory() {
+        return (MetadataReaderFactory) ReflectionHelper.get(processor, ConfigurationClassPostProcessor.class,
+                "metadataReaderFactory");
+    }
+
+    private void resetCachingMetadataReaderFactoryCache() {
+        MetadataReaderFactory metadataReaderFactory = getMetadataReaderFactory();
+        if (metadataReaderFactory != null) {
+            try {
+                ReflectionHelper.invoke(metadataReaderFactory, "clearCache");
+            } catch (Exception e) {
+                LOGGER.debug("Unable to clear MetadataReaderFactory cache");
+            }
+        }
+    }
+
+    private void resetBeanFactoryCache(BeanDefinitionRegistry registry) {
+        DefaultListableBeanFactory beanFactory = RegistryUtils.maybeRegistryToBeanFactory(registry);
+        if (beanFactory == null) {
+            return;
+        }
+
+        beanFactory.setAllowBeanDefinitionOverriding(true);
+        resetFactoryMethodCandidateCache(beanFactory);
+    }
+
+    private void removeBeanAttribute(BeanDefinitionRegistry registry, String beanName) {
+        BeanDefinition bd = registry.getBeanDefinition(beanName);
+        if (bd.hasAttribute(CONFIGURATION_CLASS_ATTRIBUTE)) {
+            bd.removeAttribute(CONFIGURATION_CLASS_ATTRIBUTE);
+        }
+    }
+
+    private void resetFactoryMethodCandidateCache(DefaultListableBeanFactory factory) {
+        Map<Class<?>, Method[]> cache = (Map<Class<?>, Method[]>) ReflectionHelper.get(factory,
+                AbstractAutowireCapableBeanFactory.class, "factoryMethodCandidateCache");
+        if (cache != null) {
+            LOGGER.debug("Cache cleared: AbstractAutowireCapableBeanFactory.factoryMethodCandidateCache");
+            cache.clear();
+        }
+    }
+
+    private void resetBeanNameCache() {
+        Map<Method, String> cache = (Map<Method, String>) ReflectionHelper.getNoException(null,
+                "org.springframework.context.annotation.BeanAnnotationHelper",
+                processor.getClass().getClassLoader(), "beanNameCache");
+        if (cache != null) {
+            LOGGER.debug("Cache cleared: BeanAnnotationHelper.beanNameCache");
+            cache.clear();
+        }
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/processor/ConfigurationClassPostProcessorTransformer.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/processor/ConfigurationClassPostProcessorTransformer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.processor;
+
+import org.hotswap.agent.annotation.OnClassLoadEvent;
+import org.hotswap.agent.javassist.CannotCompileException;
+import org.hotswap.agent.javassist.ClassPool;
+import org.hotswap.agent.javassist.CtClass;
+import org.hotswap.agent.javassist.CtMethod;
+import org.hotswap.agent.javassist.NotFoundException;
+import org.hotswap.agent.logging.AgentLogger;
+
+public class ConfigurationClassPostProcessorTransformer {
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(ConfigurationClassPostProcessorTransformer.class);
+
+    @OnClassLoadEvent(classNameRegexp = "org.springframework.context.annotation.ConfigurationClassPostProcessor")
+    public static void transform(CtClass clazz, ClassPool classPool) throws NotFoundException, CannotCompileException {
+        CtMethod method = clazz.getDeclaredMethod("processConfigBeanDefinitions",
+                new CtClass[]{classPool.get("org.springframework.beans.factory.support.BeanDefinitionRegistry")});
+        method.insertAfter("org.hotswap.agent.plugin.spring.processor.ConfigurationClassPostProcessorAgent.getInstance()." +
+                "setProcessor(this);");
+        LOGGER.debug("Class 'org.springframework.context.annotation.ConfigurationClassPostProcessor' patched with processor registration.");
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reader/AnnotatedBeanDefinitionReaderAgent.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reader/AnnotatedBeanDefinitionReaderAgent.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.reader;
+
+import org.hotswap.agent.javassist.ClassPool;
+import org.hotswap.agent.javassist.CtClass;
+import org.hotswap.agent.logging.AgentLogger;
+import org.hotswap.agent.plugin.spring.ResetSpringStaticCaches;
+import org.hotswap.agent.plugin.spring.SpringPlugin;
+import org.hotswap.agent.plugin.spring.redefine.BeanDefinitionResolverSupport;
+import org.hotswap.agent.util.PluginManagerInvoker;
+import org.hotswap.agent.util.ReflectionHelper;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
+import org.springframework.context.annotation.AnnotatedBeanDefinitionReader;
+import org.springframework.context.annotation.ScannedGenericBeanDefinition;
+import org.springframework.context.annotation.ScopeMetadataResolver;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class AnnotatedBeanDefinitionReaderAgent extends BeanDefinitionResolverSupport {
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(AnnotatedBeanDefinitionReaderAgent.class);
+
+    private static final Map<AnnotatedBeanDefinitionReader, AnnotatedBeanDefinitionReaderAgent> instances = new HashMap<>();
+
+    public static boolean reloadFlag = false;
+
+    private final AnnotatedBeanDefinitionReader reader;
+    private final BeanDefinitionRegistry registry;
+    private final ScopeMetadataResolver scopeMetadataResolver;
+    private final BeanNameGenerator beanNameGenerator;
+    private final SimpleMetadataReaderFactory metadataReaderFactory;
+
+    private final Set<String> componentClasses = new HashSet<>();
+
+    /**
+     * Get instance of AnnotatedBeanDefinitionReaderAgent for given reader
+     *
+     * @param reader AnnotatedBeanDefinitionReader
+     * @return AnnotatedBeanDefinitionReaderAgent
+     * @see AnnotatedBeanDefinitionReaderTransformer#transform(CtClass, ClassPool)
+     */
+    public static AnnotatedBeanDefinitionReaderAgent getInstance(AnnotatedBeanDefinitionReader reader) {
+        if (!instances.containsKey(reader)) {
+            instances.put(reader, new AnnotatedBeanDefinitionReaderAgent(reader));
+        }
+
+        return instances.get(reader);
+    }
+
+    public static AnnotatedBeanDefinitionReaderAgent getInstance(String componentClass) {
+        for (AnnotatedBeanDefinitionReaderAgent instance : instances.values()) {
+            if (instance.componentClasses.contains(componentClass)) {
+                return instance;
+            }
+        }
+
+        return null;
+    }
+
+    private AnnotatedBeanDefinitionReaderAgent(AnnotatedBeanDefinitionReader reader) {
+        this.reader = reader;
+
+        this.registry = reader.getRegistry();
+        this.scopeMetadataResolver = (ScopeMetadataResolver) ReflectionHelper.get(reader, "scopeMetadataResolver");
+        this.beanNameGenerator = (BeanNameGenerator) ReflectionHelper.get(reader, "beanNameGenerator");
+        this.metadataReaderFactory = new SimpleMetadataReaderFactory(reader.getClass().getClassLoader());
+    }
+
+    public void register(Class<?>... componentClasses) {
+        if (componentClasses == null) {
+            return;
+        }
+
+        for (Class<?> componentClass : componentClasses) {
+            this.componentClasses.add(componentClass.getName());
+            PluginManagerInvoker.callPluginMethod(SpringPlugin.class, getClass().getClassLoader(),
+                    "registerComponentClass", new Class[]{String.class}, new Object[]{componentClass.getName()});
+        }
+    }
+
+    /**
+     * Called by a reflection command from SpringPlugin transformer.
+     *
+     * @param appClassLoader  the class loader - container or application class loader.
+     * @param className       the class name to be reloaded
+     * @param classDefinition new class definition
+     */
+    public static void refreshClass(ClassLoader appClassLoader, String className, byte[] classDefinition) {
+        ResetSpringStaticCaches.reset();
+
+        AnnotatedBeanDefinitionReaderAgent instance = getInstance(className);
+        if (instance == null) {
+            LOGGER.error("Unable to find AnnotatedBeanDefinitionReaderAgent instance for class {}", className);
+            return;
+        }
+
+        instance.redefine(appClassLoader, classDefinition);
+
+        reloadFlag = false;
+    }
+
+    @Override
+    protected void postProcessBeanDefinition(ScannedGenericBeanDefinition candidate, String beanName) {
+        // no-op
+    }
+
+    @Override
+    protected void registerBeanDefinition(BeanDefinitionHolder definitionHolder, BeanDefinitionRegistry registry) {
+        ReflectionHelper.invoke(null, BeanDefinitionReaderUtils.class,
+                "registerBeanDefinition", new Class[]{BeanDefinitionHolder.class, BeanDefinitionRegistry.class},
+                definitionHolder, registry);
+    }
+
+    @Override
+    protected BeanDefinitionRegistry getBeanDefinitionRegistry() {
+        return this.registry;
+    }
+
+    @Override
+    protected BeanNameGenerator getBeanNameGenerator() {
+        return this.beanNameGenerator;
+    }
+
+    @Override
+    protected ScopeMetadataResolver getScopeMetadataResolver() {
+        return this.scopeMetadataResolver;
+    }
+
+    @Override
+    protected MetadataReaderFactory getMetadataReaderFactory() {
+        return this.metadataReaderFactory;
+    }
+
+    @Override
+    protected boolean isCandidateComponent(MetadataReader metadataReader, AnnotatedBeanDefinition beanDefinition) {
+        Object o = ReflectionHelper.getNoException(reader, AnnotatedBeanDefinitionReader.class, "conditionEvaluator");
+        if (o != null) {
+            Boolean b = (Boolean) ReflectionHelper.invokeNoException(o,
+                    "org.springframework.context.annotation.ConditionEvaluator",
+                    reader.getClass().getClassLoader(),
+                    "shouldSkip",
+                    new Class[]{AnnotatedTypeMetadata.class},
+                    beanDefinition.getMetadata());
+            return b != null && !b;
+        }
+        return false;
+    }
+
+    @Override
+    protected boolean checkCandidate(String beanName, BeanDefinition candidate) {
+        return true;
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reader/AnnotatedBeanDefinitionReaderTransformer.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reader/AnnotatedBeanDefinitionReaderTransformer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.reader;
+
+import org.hotswap.agent.annotation.OnClassLoadEvent;
+import org.hotswap.agent.javassist.CannotCompileException;
+import org.hotswap.agent.javassist.ClassPool;
+import org.hotswap.agent.javassist.CtClass;
+import org.hotswap.agent.javassist.CtMethod;
+import org.hotswap.agent.javassist.NotFoundException;
+import org.hotswap.agent.logging.AgentLogger;
+
+public class AnnotatedBeanDefinitionReaderTransformer {
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(AnnotatedBeanDefinitionReaderTransformer.class);
+
+    @OnClassLoadEvent(classNameRegexp = "org.springframework.context.annotation.AnnotatedBeanDefinitionReader")
+    public static void transform(CtClass clazz, ClassPool classPool) throws NotFoundException, CannotCompileException {
+        CtMethod method = clazz.getDeclaredMethod("register", new CtClass[]{classPool.get(Class.class.getName() + "[]")});
+        method.insertAfter("org.hotswap.agent.plugin.spring.reader.AnnotatedBeanDefinitionReaderAgent.getInstance($0).register($1);");
+        LOGGER.debug("Class 'org.springframework.context.annotation.AnnotatedBeanDefinitionReader' patched");
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reader/ComponentClassRefreshCommand.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reader/ComponentClassRefreshCommand.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.reader;
+
+import org.hotswap.agent.command.MergeableCommand;
+import org.hotswap.agent.logging.AgentLogger;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+public class ComponentClassRefreshCommand extends MergeableCommand {
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(ComponentClassRefreshCommand.class);
+
+    private final ClassLoader classLoader;
+    private final String componentClass;
+    private final byte[] classDefinition;
+
+
+    public ComponentClassRefreshCommand(ClassLoader classLoader, String componentClass, byte[] classDefinition) {
+        this.classLoader = classLoader;
+        this.componentClass = componentClass;
+        this.classDefinition = classDefinition;
+    }
+
+    @Override
+    public void executeCommand() {
+        LOGGER.debug("Executing AnnotatedBeanDefinitionReaderAgent.refreshClass('{}')", componentClass);
+
+        try {
+            Class<?> clazz = Class.forName("org.hotswap.agent.plugin.spring.reader.AnnotatedBeanDefinitionReaderAgent", true, classLoader);
+            Method method = clazz.getMethod("refreshClass", ClassLoader.class, String.class, byte[].class);
+            method.invoke(null, classLoader, componentClass, classDefinition);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Plugin error, method not found", e);
+        } catch (InvocationTargetException e) {
+            LOGGER.error("Error refreshing class {} in classLoader {}", e, componentClass, classLoader);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Plugin error, illegal access", e);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Plugin error, Spring class not found in application classloader", e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ComponentClassRefreshCommand that = (ComponentClassRefreshCommand) o;
+        return Objects.equals(classLoader, that.classLoader) && Objects.equals(componentClass, that.componentClass);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(classLoader, componentClass);
+    }
+
+    @Override
+    public String toString() {
+        return "ComponentClassRefreshCommand{" +
+                "classLoader=" + classLoader +
+                ", componentClass='" + componentClass + '\'' +
+                '}';
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reader/ComponentClassTransformer.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reader/ComponentClassTransformer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.reader;
+
+import org.hotswap.agent.command.Scheduler;
+import org.hotswap.agent.plugin.spring.SpringChangesAnalyzer;
+import org.hotswap.agent.util.HaClassFileTransformer;
+
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.ProtectionDomain;
+import java.util.Objects;
+
+public class ComponentClassTransformer implements HaClassFileTransformer {
+    private final ClassLoader appClassLoader;
+    private final Scheduler scheduler;
+    private final String componentClass;
+
+    public ComponentClassTransformer(ClassLoader appClassLoader, Scheduler scheduler, String componentClass) {
+        this.appClassLoader = appClassLoader;
+        this.scheduler = scheduler;
+        this.componentClass = componentClass;
+    }
+
+    @Override
+    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
+                            ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+        final SpringChangesAnalyzer analyzer = new SpringChangesAnalyzer(appClassLoader);
+        if (classBeingRedefined != null && className.replace('/', '.').equals(componentClass)) {
+            if (analyzer.isReloadNeeded(classBeingRedefined, classfileBuffer)) {
+                scheduler.scheduleCommand(new ComponentClassRefreshCommand(classBeingRedefined.getClassLoader(),
+                        componentClass, classfileBuffer));
+            }
+        }
+
+        return classfileBuffer;
+    }
+
+    @Override
+    public boolean isForRedefinitionOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ComponentClassTransformer that = (ComponentClassTransformer) o;
+        return Objects.equals(appClassLoader, that.appClassLoader) && Objects.equals(componentClass, that.componentClass);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(appClassLoader, componentClass);
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/redefine/BeanDefinitionResolver.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/redefine/BeanDefinitionResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.redefine;
+
+/**
+ * Redefine spring bean definition.
+ */
+public interface BeanDefinitionResolver {
+    /**
+     * Redefine a spring bean definition with the give class byte array.
+     *
+     * @param appClassLoader  application classloader
+     * @param classDefinition new class definition
+     */
+    void redefine(ClassLoader appClassLoader, byte[] classDefinition);
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/redefine/BeanDefinitionResolverSupport.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/redefine/BeanDefinitionResolverSupport.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.redefine;
+
+import org.hotswap.agent.logging.AgentLogger;
+import org.hotswap.agent.plugin.spring.ResetBeanPostProcessorCaches;
+import org.hotswap.agent.plugin.spring.ResetRequestMappingCaches;
+import org.hotswap.agent.plugin.spring.ResetSpringStaticCaches;
+import org.hotswap.agent.plugin.spring.ResetTransactionAttributeCaches;
+import org.hotswap.agent.plugin.spring.getbean.ProxyReplacer;
+import org.hotswap.agent.plugin.spring.processor.ConfigurationClassPostProcessorAgent;
+import org.hotswap.agent.util.ReflectionHelper;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.annotation.AnnotationConfigUtils;
+import org.springframework.context.annotation.ScannedGenericBeanDefinition;
+import org.springframework.context.annotation.ScopeMetadata;
+import org.springframework.context.annotation.ScopeMetadataResolver;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+
+import java.io.IOException;
+
+import static org.hotswap.agent.plugin.spring.utils.RegistryUtils.maybeRegistryToBeanFactory;
+
+public abstract class BeanDefinitionResolverSupport implements BeanDefinitionResolver {
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(BeanDefinitionResolverSupport.class);
+    private static final Object LOCK = new Object();
+
+    @Override
+    public void redefine(ClassLoader appClassLoader, byte[] classDefinition) {
+        ScannedGenericBeanDefinition candidate = resolveBeanDefinition(appClassLoader, classDefinition);
+        if (candidate != null) {
+            defineBean(candidate);
+        }
+    }
+
+    /**
+     * Resolve bean definition from class definition if applicable.
+     *
+     * @param appClassLoader the class loader - container or application class loader.
+     * @param bytes          class definition.
+     * @return the definition or null if not a spring bean
+     */
+    private ScannedGenericBeanDefinition resolveBeanDefinition(ClassLoader appClassLoader, byte[] bytes) {
+        try {
+            MetadataReaderFactory metadataReaderFactory = getMetadataReaderFactory();
+            Resource resource = new ByteArrayResource(bytes);
+            MetadataReader metadataReader = metadataReaderFactory.getMetadataReader(resource);
+            ScannedGenericBeanDefinition bd = new ScannedGenericBeanDefinition(metadataReader);
+            bd.setResource(resource);
+            bd.setSource(resource);
+            return (isCandidateComponent(metadataReader, bd) ? bd : null);
+        } catch (IOException e) {
+            LOGGER.trace("Unable to resolve bean definition because exception occurs when read bean's metadata", e);
+            return null;
+        }
+    }
+
+    /**
+     * Resolve candidate to a bean definition and (re)load in Spring.
+     * Synchronize to avoid parallel bean definition - usually on reload the beans are interrelated
+     * and parallel load will cause concurrent modification exception.
+     *
+     * @param candidate the candidate to reload
+     */
+    private void defineBean(ScannedGenericBeanDefinition candidate) {
+        synchronized (LOCK) {
+            BeanDefinitionRegistry registry = getBeanDefinitionRegistry();
+
+            // set scope
+            ScopeMetadata scopeMetadata = getScopeMetadataResolver().resolveScopeMetadata(candidate);
+            candidate.setScope(scopeMetadata.getScopeName());
+
+            // process bean definition
+            String beanName = getBeanNameGenerator().generateBeanName(candidate, registry);
+            processBeanDefinition(beanName, candidate);
+
+            // reset cache
+            resetBeanFactory();
+            resetStaticCaches();
+
+            // remove bean
+            removeBean(beanName);
+
+            if (checkCandidate(beanName, candidate)) {
+                BeanDefinitionHolder definitionHolder = new BeanDefinitionHolder(candidate, beanName);
+                definitionHolder = applyScopedProxyMode(scopeMetadata, definitionHolder, registry);
+
+                LOGGER.reload("Registering Spring bean '{}'", beanName);
+                LOGGER.debug("Bean definition '{}'", beanName, candidate);
+
+                // register new bean definition
+                registerBeanDefinition(definitionHolder, registry);
+
+                // continue to post-process bean definition registry if the changed class is an instance of
+                // configuration class.
+                boolean isConfigurationClass = isConfigurationClassCandidate(candidate);
+                if (isConfigurationClass) {
+                    LOGGER.debug("Bean definition '{}' is a configuration class", beanName);
+                    removeBeansFromFactoryBean(beanName);
+                    ConfigurationClassPostProcessorAgent.getInstance().postProcess(registry, beanName);
+                }
+
+                ProxyReplacer.clearAllProxies();
+                freezeConfiguration();
+            }
+        }
+    }
+
+    /**
+     * Get the bean definition registry.
+     *
+     * @return the bean definition registry
+     */
+    protected abstract BeanDefinitionRegistry getBeanDefinitionRegistry();
+
+    /**
+     * Get the bean name generator.
+     *
+     * @return the bean name generator
+     */
+    protected abstract BeanNameGenerator getBeanNameGenerator();
+
+    /**
+     * Registry bean definition to registry.
+     *
+     * @param definitionHolder the bean definition holder
+     * @param registry         the bean definition registry
+     */
+    protected abstract void registerBeanDefinition(BeanDefinitionHolder definitionHolder, BeanDefinitionRegistry registry);
+
+    /**
+     * Get the scope metadata resolver.
+     *
+     * @return the scope metadata resolver
+     */
+    protected abstract ScopeMetadataResolver getScopeMetadataResolver();
+
+    /**
+     * Get the metadata reader factory.
+     *
+     * @return the metadata reader factory
+     */
+    protected abstract MetadataReaderFactory getMetadataReaderFactory();
+
+    /**
+     * Post process bean definition before register it to the bean definition registry.
+     *
+     * @param candidate the candidate bean definition
+     * @param beanName  the bean name
+     */
+    protected abstract void postProcessBeanDefinition(ScannedGenericBeanDefinition candidate, String beanName);
+
+    /**
+     * Check if the candidate bean definition is a valid spring component
+     *
+     * @param metadataReader the metadata reader
+     * @param beanDefinition the bean definition
+     * @return true if the candidate is a valid spring component
+     */
+    protected abstract boolean isCandidateComponent(MetadataReader metadataReader, AnnotatedBeanDefinition beanDefinition);
+
+
+    /**
+     * Check the given candidate's bean name, determining whether the corresponding bean definition needs to be
+     * registered or conflicts with an existing definition.
+     *
+     * @param beanName  the suggested name for the bean
+     * @param candidate the candidate bean definition
+     * @return true if the bean can be registered as-is
+     */
+    protected abstract boolean checkCandidate(String beanName, BeanDefinition candidate);
+
+    private void resetBeanFactory() {
+        DefaultListableBeanFactory bf = maybeRegistryToBeanFactory(getBeanDefinitionRegistry());
+        if (bf != null) {
+            ResetRequestMappingCaches.reset(bf);
+            ResetBeanPostProcessorCaches.reset(bf);
+            ResetTransactionAttributeCaches.reset(bf);
+        }
+    }
+
+    private void resetStaticCaches() {
+        ResetSpringStaticCaches.reset();
+    }
+
+    private void processBeanDefinition(String beanName, ScannedGenericBeanDefinition candidate) {
+        postProcessBeanDefinition(candidate, beanName);
+        processCommonDefinitionAnnotations(candidate);
+    }
+
+    private static BeanDefinitionHolder applyScopedProxyMode(ScopeMetadata metadata, BeanDefinitionHolder definition,
+                                                             BeanDefinitionRegistry registry) {
+        return (BeanDefinitionHolder) ReflectionHelper.invoke(null, AnnotationConfigUtils.class, "applyScopedProxyMode",
+                new Class[]{ScopeMetadata.class, BeanDefinitionHolder.class, BeanDefinitionRegistry.class},
+                metadata, definition, registry);
+
+    }
+
+    private static void processCommonDefinitionAnnotations(ScannedGenericBeanDefinition candidate) {
+        ReflectionHelper.invoke(null, AnnotationConfigUtils.class, "processCommonDefinitionAnnotations",
+                new Class[]{AnnotatedBeanDefinition.class}, candidate);
+    }
+
+    private boolean isConfigurationClassCandidate(BeanDefinition beanDef) {
+        MetadataReaderFactory metadataReaderFactory = getMetadataReaderFactory();
+        Object o = ReflectionHelper.invokeNoException(null,
+                "org.springframework.context.annotation.ConfigurationClassUtils",
+                metadataReaderFactory.getClass().getClassLoader(),
+                "checkConfigurationClassCandidate",
+                new Class[]{BeanDefinition.class, MetadataReaderFactory.class},
+                beanDef, metadataReaderFactory);
+        return o != null && (Boolean) o;
+    }
+
+    /**
+     * If registry contains the bean, remove it first (destroying existing singletons).
+     *
+     * @param beanName name of the bean
+     */
+    private void removeBean(String beanName) {
+        BeanDefinitionRegistry registry = getBeanDefinitionRegistry();
+        if (registry.containsBeanDefinition(beanName)) {
+            LOGGER.debug("Removing bean definition '{}'", beanName);
+            registry.removeBeanDefinition(beanName);
+        }
+    }
+
+    private void removeBeansFromFactoryBean(String factoryBean) {
+        BeanDefinitionRegistry registry = getBeanDefinitionRegistry();
+        for (String name : registry.getBeanDefinitionNames()) {
+            if (factoryBean.equals(registry.getBeanDefinition(name).getFactoryBeanName())) {
+                registry.removeBeanDefinition(name);
+                LOGGER.debug("Removing bean definition '{}' since it's created from factory bean '{}'", name, factoryBean);
+            }
+        }
+    }
+
+    /**
+     * Freeze all bean definitions
+     */
+    private void freezeConfiguration() {
+        BeanDefinitionRegistry registry = getBeanDefinitionRegistry();
+        if (registry instanceof DefaultListableBeanFactory) {
+            ((DefaultListableBeanFactory) registry).freezeConfiguration();
+        } else if (registry instanceof GenericApplicationContext) {
+            (((GenericApplicationContext) registry).getDefaultListableBeanFactory()).freezeConfiguration();
+        }
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/ClassPathBeanDefinitionScannerAgent.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/ClassPathBeanDefinitionScannerAgent.java
@@ -19,13 +19,9 @@
 package org.hotswap.agent.plugin.spring.scanner;
 
 import org.hotswap.agent.logging.AgentLogger;
-import org.hotswap.agent.plugin.spring.ResetBeanPostProcessorCaches;
-import org.hotswap.agent.plugin.spring.ResetRequestMappingCaches;
 import org.hotswap.agent.plugin.spring.ResetSpringStaticCaches;
-import org.hotswap.agent.plugin.spring.ResetTransactionAttributeCaches;
 import org.hotswap.agent.plugin.spring.SpringPlugin;
-import org.hotswap.agent.plugin.spring.getbean.ProxyReplacer;
-import org.hotswap.agent.plugin.spring.processor.ConfigurationClassPostProcessorAgent;
+import org.hotswap.agent.plugin.spring.redefine.BeanDefinitionResolverSupport;
 import org.hotswap.agent.util.PluginManagerInvoker;
 import org.hotswap.agent.util.ReflectionHelper;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
@@ -34,27 +30,18 @@ import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanNameGenerator;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
-import org.springframework.context.annotation.AnnotationConfigUtils;
 import org.springframework.context.annotation.ClassPathBeanDefinitionScanner;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.context.annotation.ScannedGenericBeanDefinition;
-import org.springframework.context.annotation.ScopeMetadata;
 import org.springframework.context.annotation.ScopeMetadataResolver;
-import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.Resource;
 import org.springframework.core.type.classreading.CachingMetadataReaderFactory;
 import org.springframework.core.type.classreading.MetadataReader;
 import org.springframework.core.type.classreading.MetadataReaderFactory;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.hotswap.agent.plugin.spring.utils.RegistryUtils.maybeRegistryToBeanFactory;
 
 
 /**
@@ -62,10 +49,10 @@ import static org.hotswap.agent.plugin.spring.utils.RegistryUtils.maybeRegistryT
  *
  * @author Jiri Bubnik
  */
-public class ClassPathBeanDefinitionScannerAgent {
-    private static AgentLogger LOGGER = AgentLogger.getLogger(ClassPathBeanDefinitionScannerAgent.class);
+public class ClassPathBeanDefinitionScannerAgent extends BeanDefinitionResolverSupport {
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(ClassPathBeanDefinitionScannerAgent.class);
 
-    private static Map<ClassPathBeanDefinitionScanner, ClassPathBeanDefinitionScannerAgent> instances = new HashMap<>();
+    private static final Map<ClassPathBeanDefinitionScanner, ClassPathBeanDefinitionScannerAgent> instances = new HashMap<>();
 
     /**
      * Flag to check reload status.
@@ -75,19 +62,19 @@ public class ClassPathBeanDefinitionScannerAgent {
     public static boolean reloadFlag = false;
 
     // target scanner this agent shadows
-    ClassPathBeanDefinitionScanner scanner;
+    private final ClassPathBeanDefinitionScanner scanner;
 
     // list of basePackages registered with target scanner
-    Set<String> basePackages = new HashSet<>();
+    private final Set<String> basePackages = new HashSet<>();
 
     // registry obtained from the scanner
-    BeanDefinitionRegistry registry;
+    private final BeanDefinitionRegistry registry;
 
     // metadata resolver obtained from the scanner
-    ScopeMetadataResolver scopeMetadataResolver;
+    private final ScopeMetadataResolver scopeMetadataResolver;
 
     // bean name generator obtained from the scanner
-    BeanNameGenerator beanNameGenerator;
+    private final BeanNameGenerator beanNameGenerator;
 
     /**
      * Return an agent instance for a scanner. If the instance does not exists yet, it is created.
@@ -145,9 +132,8 @@ public class ClassPathBeanDefinitionScannerAgent {
      * @param appClassLoader  the class loader - container or application class loader.
      * @param basePackage     base package on witch the transformer was registered, used to obtain associated scanner.
      * @param classDefinition new class definition
-     * @throws IOException error working with classDefinition
      */
-    public static void refreshClass(ClassLoader appClassLoader, String basePackage, byte[] classDefinition) throws IOException {
+    public static void refreshClass(ClassLoader appClassLoader, String basePackage, byte[] classDefinition) {
         ResetSpringStaticCaches.reset();
 
         ClassPathBeanDefinitionScannerAgent scannerAgent = getInstance(basePackage);
@@ -156,209 +142,86 @@ public class ClassPathBeanDefinitionScannerAgent {
             return;
         }
 
-        BeanDefinition beanDefinition = scannerAgent.resolveBeanDefinition(appClassLoader, classDefinition);
-        if (beanDefinition != null) {
-            scannerAgent.defineBean(beanDefinition);
-        }
+        scannerAgent.redefine(appClassLoader, classDefinition);
 
         reloadFlag = false;
     }
 
+    @Override
+    protected MetadataReaderFactory getMetadataReaderFactory() {
+        MetadataReaderFactory factory = (MetadataReaderFactory) ReflectionHelper.get(scanner, "metadataReaderFactory");
 
-    /**
-     * Resolve candidate to a bean definition and (re)load in Spring.
-     * Synchronize to avoid parallel bean definition - usually on reload the beans are interrelated
-     * and parallel load will cause concurrent modification exception.
-     *
-     * @param candidate the candidate to reload
-     */
-    public void defineBean(BeanDefinition candidate) {
-        synchronized (getClass()) { // TODO sychronize on DefaultListableFactory.beanDefinitionMap?
-
-            ScopeMetadata scopeMetadata = this.scopeMetadataResolver.resolveScopeMetadata(candidate);
-            candidate.setScope(scopeMetadata.getScopeName());
-            String beanName = this.beanNameGenerator.generateBeanName(candidate, registry);
-
-            if (candidate instanceof AbstractBeanDefinition) {
-                postProcessBeanDefinition((AbstractBeanDefinition) candidate, beanName);
-            }
-            if (candidate instanceof AnnotatedBeanDefinition) {
-                processCommonDefinitionAnnotations((AnnotatedBeanDefinition) candidate);
-            }
-
-            DefaultListableBeanFactory bf = maybeRegistryToBeanFactory(registry);
-            if (bf != null) {
-                ResetRequestMappingCaches.reset(bf);
-                ResetBeanPostProcessorCaches.reset(bf);
-                ResetTransactionAttributeCaches.reset(bf);
-            }
-
-            ResetSpringStaticCaches.reset();
-
-            removeBean(beanName);
-
-            if (checkCandidate(beanName, candidate)) {
-
-                BeanDefinitionHolder definitionHolder = new BeanDefinitionHolder(candidate, beanName);
-                definitionHolder = applyScopedProxyMode(scopeMetadata, definitionHolder, registry);
-
-                LOGGER.reload("Registering Spring bean '{}'", beanName);
-                LOGGER.debug("Bean definition '{}'", beanName, candidate);
-                registerBeanDefinition(definitionHolder, registry);
-
-                boolean isConfigurationClass = isConfigurationClassCandidate(candidate);
-                if (isConfigurationClass) {
-                    LOGGER.debug("Bean definition '{}' is a configuration class", beanName);
-                    removeBeansFromFactoryBean(beanName);
-                    ConfigurationClassPostProcessorAgent.getInstance().postProcess(registry, beanName);
-                }
-
-                ProxyReplacer.clearAllProxies();
-                freezeConfiguration();
-            }
-        }
-
-
-    }
-
-    /**
-     * If registry contains the bean, remove it first (destroying existing singletons).
-     *
-     * @param beanName name of the bean
-     */
-    private void removeBean(String beanName) {
-        if (registry.containsBeanDefinition(beanName)) {
-            LOGGER.debug("Removing bean definition '{}'", beanName);
-            registry.removeBeanDefinition(beanName);
-        }
-    }
-
-    private void removeBeansFromFactoryBean(String factoryBean) {
-        for (String name : registry.getBeanDefinitionNames()) {
-            if (factoryBean.equals(registry.getBeanDefinition(name).getFactoryBeanName())) {
-                registry.removeBeanDefinition(name);
-                LOGGER.debug("Removing bean definition '{}' since it's created from factory bean '{}'", name, factoryBean);
-            }
-        }
-    }
-
-    // rerun freez configuration - this method is enhanced with cache reset
-    private void freezeConfiguration() {
-        if (registry instanceof DefaultListableBeanFactory) {
-            ((DefaultListableBeanFactory) registry).freezeConfiguration();
-        } else if (registry instanceof GenericApplicationContext) {
-            (((GenericApplicationContext) registry).getDefaultListableBeanFactory()).freezeConfiguration();
-        }
-    }
-
-    /**
-     * Resolve bean definition from class definition if applicable.
-     *
-     * @param appClassLoader the class loader - container or application class loader.
-     * @param bytes          class definition.
-     * @return the definition or null if not a spring bean
-     * @throws IOException
-     */
-    public BeanDefinition resolveBeanDefinition(ClassLoader appClassLoader, byte[] bytes) throws IOException {
-        resetCachingMetadataReaderFactoryCache();
-
-        Resource resource = new ByteArrayResource(bytes);
-        MetadataReader metadataReader = getMetadataReader(appClassLoader, resource);
-        ScannedGenericBeanDefinition sbd = new ScannedGenericBeanDefinition(metadataReader);
-        sbd.setResource(resource);
-        sbd.setSource(resource);
-
-        if (isCandidateComponent(metadataReader)) {
-            if (isCandidateComponent(sbd)) {
-                LOGGER.debug("Identified candidate component class '{}'", metadataReader.getClassMetadata().getClassName());
-                return sbd;
-            } else {
-                LOGGER.debug("Ignored because not a concrete top-level class '{}'", metadataReader.getClassMetadata().getClassName());
-                return null;
-            }
-        } else if (isConfigurationClassCandidate(sbd)) {
-            return sbd;
-        } else {
-            LOGGER.trace("Ignored because not matching any filter '{}' ", metadataReader.getClassMetadata().getClassName());
-            return null;
-        }
-    }
-
-    private MetadataReader getMetadataReader(ClassLoader appClassLoader, Resource resource) throws IOException {
-        ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
-        try {
-            Thread.currentThread().setContextClassLoader(appClassLoader);
-            return getMetadataReaderFactory().getMetadataReader(resource);
-        } finally {
-            Thread.currentThread().setContextClassLoader(oldClassLoader);
-        }
-    }
-
-    private MetadataReaderFactory getMetadataReaderFactory() {
-        return (MetadataReaderFactory) ReflectionHelper.get(scanner, "metadataReaderFactory");
-    }
-
-    // metadataReader contains cache of loaded classes, reset this cache before BeanDefinition is resolved
-    private void resetCachingMetadataReaderFactoryCache() {
-        if (getMetadataReaderFactory() instanceof CachingMetadataReaderFactory) {
-            Map metadataReaderCache = (Map) ReflectionHelper.getNoException(getMetadataReaderFactory(),
-                    CachingMetadataReaderFactory.class, "metadataReaderCache");
+        // metadataReader contains cache of loaded classes, reset this cache before BeanDefinition is resolved
+        if (factory instanceof CachingMetadataReaderFactory) {
+            Map metadataReaderCache = (Map) ReflectionHelper.getNoException(factory,
+                    CachingMetadataReaderFactory.class,
+                    "metadataReaderCache");
 
             if (metadataReaderCache == null)
-                metadataReaderCache = (Map) ReflectionHelper.getNoException(getMetadataReaderFactory(),
-                        CachingMetadataReaderFactory.class, "classReaderCache");
+                metadataReaderCache = (Map) ReflectionHelper.getNoException(factory,
+                        CachingMetadataReaderFactory.class,
+                        "classReaderCache");
 
             if (metadataReaderCache != null) {
                 metadataReaderCache.clear();
                 LOGGER.debug("Cache cleared: CachingMetadataReaderFactory.clearCache()");
             } else {
-                LOGGER.warning("Cache NOT cleared: neither CachingMetadataReaderFactory.metadataReaderCache nor clearCache does not exist.");
+                LOGGER.warning("Cache NOT cleared: neither CachingMetadataReaderFactory.metadataReaderCache nor " +
+                        "clearCache does not exist.");
             }
-
-
         }
+
+        return factory;
     }
 
 
-    ////////////////////////////////////////////////////////////////////////////////////////////
-    // Access private / protected members
-    ////////////////////////////////////////////////////////////////////////////////////////////
-
-    private boolean isConfigurationClassCandidate(BeanDefinition beanDef) {
-        MetadataReaderFactory metadataReaderFactory = getMetadataReaderFactory();
-        Object o = ReflectionHelper.invokeNoException(null,
-                "org.springframework.context.annotation.ConfigurationClassUtils",
-                scanner.getClass().getClassLoader(),
-                "checkConfigurationClassCandidate",
-                new Class[]{BeanDefinition.class, MetadataReaderFactory.class},
-                beanDef, metadataReaderFactory);
-        return o != null && (Boolean) o;
+    @Override
+    protected BeanDefinitionRegistry getBeanDefinitionRegistry() {
+        return this.registry;
     }
 
-    private BeanDefinitionHolder applyScopedProxyMode(
-            ScopeMetadata metadata, BeanDefinitionHolder definition, BeanDefinitionRegistry registry) {
-        return (BeanDefinitionHolder) ReflectionHelper.invoke(null, AnnotationConfigUtils.class,
-                "applyScopedProxyMode", new Class[]{ScopeMetadata.class, BeanDefinitionHolder.class, BeanDefinitionRegistry.class},
-                metadata, definition, registry);
-
+    @Override
+    protected BeanNameGenerator getBeanNameGenerator() {
+        return this.beanNameGenerator;
     }
 
-    private void registerBeanDefinition(BeanDefinitionHolder definitionHolder, BeanDefinitionRegistry registry) {
-        ReflectionHelper.invoke(scanner, ClassPathBeanDefinitionScanner.class,
-                "registerBeanDefinition", new Class[]{BeanDefinitionHolder.class, BeanDefinitionRegistry.class}, definitionHolder, registry);
+    @Override
+    protected ScopeMetadataResolver getScopeMetadataResolver() {
+        return this.scopeMetadataResolver;
     }
 
-    private boolean checkCandidate(String beanName, BeanDefinition candidate) {
+    @Override
+    protected boolean checkCandidate(String beanName, BeanDefinition candidate) {
         return (Boolean) ReflectionHelper.invoke(scanner, ClassPathBeanDefinitionScanner.class,
                 "checkCandidate", new Class[]{String.class, BeanDefinition.class}, beanName, candidate);
     }
 
-    private void processCommonDefinitionAnnotations(AnnotatedBeanDefinition candidate) {
-        ReflectionHelper.invoke(null, AnnotationConfigUtils.class,
-                "processCommonDefinitionAnnotations", new Class[]{AnnotatedBeanDefinition.class}, candidate);
+    @Override
+    protected boolean isCandidateComponent(MetadataReader metadataReader, AnnotatedBeanDefinition beanDefinition) {
+        String className = metadataReader.getClassMetadata().getClassName();
+        if (isCandidateComponent(metadataReader)) {
+            if (isCandidateComponent(beanDefinition)) {
+                LOGGER.debug("Identified candidate component class '{}'", className);
+                return true;
+            } else {
+                LOGGER.debug("Ignored because not a concrete top-level class '{}'", className);
+                return false;
+            }
+        } else {
+            LOGGER.trace("Ignored because not matching any filter '{}' ", className);
+            return false;
+        }
     }
 
-    private void postProcessBeanDefinition(AbstractBeanDefinition candidate, String beanName) {
+    @Override
+    protected void registerBeanDefinition(BeanDefinitionHolder definitionHolder, BeanDefinitionRegistry registry) {
+        ReflectionHelper.invoke(scanner, ClassPathBeanDefinitionScanner.class, "registerBeanDefinition",
+                new Class[]{BeanDefinitionHolder.class, BeanDefinitionRegistry.class},
+                definitionHolder, registry);
+    }
+
+    @Override
+    protected void postProcessBeanDefinition(ScannedGenericBeanDefinition candidate, String beanName) {
         ReflectionHelper.invoke(scanner, ClassPathBeanDefinitionScanner.class,
                 "postProcessBeanDefinition", new Class[]{AbstractBeanDefinition.class, String.class},
                 candidate, beanName);

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/ClassPathBeanDefinitionScannerTransformer.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/ClassPathBeanDefinitionScannerTransformer.java
@@ -19,7 +19,11 @@
 package org.hotswap.agent.plugin.spring.scanner;
 
 import org.hotswap.agent.annotation.OnClassLoadEvent;
-import org.hotswap.agent.javassist.*;
+import org.hotswap.agent.javassist.CannotCompileException;
+import org.hotswap.agent.javassist.ClassPool;
+import org.hotswap.agent.javassist.CtClass;
+import org.hotswap.agent.javassist.CtMethod;
+import org.hotswap.agent.javassist.NotFoundException;
 import org.hotswap.agent.logging.AgentLogger;
 import org.hotswap.agent.plugin.spring.SpringPlugin;
 
@@ -30,7 +34,7 @@ import org.hotswap.agent.plugin.spring.SpringPlugin;
  * <pre>&lt;context:component-scan base-package="org.hotswap.agent.plugin.spring.testBeans"/&gt;</pre>
  */
 public class ClassPathBeanDefinitionScannerTransformer {
-    private static AgentLogger LOGGER = AgentLogger.getLogger(ClassPathBeanDefinitionScannerTransformer.class);
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(ClassPathBeanDefinitionScannerTransformer.class);
 
     /**
      * Insert at the beginning of the method:
@@ -44,15 +48,19 @@ public class ClassPathBeanDefinitionScannerTransformer {
     public static void transform(CtClass clazz, ClassPool classPool) throws NotFoundException, CannotCompileException {
         if (SpringPlugin.basePackagePrefixes == null) {
             CtMethod method = clazz.getDeclaredMethod("findCandidateComponents", new CtClass[]{classPool.get("java.lang.String")});
-            method.insertAfter("if (this instanceof org.springframework.context.annotation.ClassPathBeanDefinitionScanner) {" +
-                    "org.hotswap.agent.plugin.spring.scanner.ClassPathBeanDefinitionScannerAgent." +
-                    "getInstance((org.springframework.context.annotation.ClassPathBeanDefinitionScanner)this)." +
-                    "registerBasePackage($1);" +
+            method.insertAfter(
+                    "if (this instanceof org.springframework.context.annotation.ClassPathBeanDefinitionScanner) {" +
+                    "  if (org.hotswap.agent.plugin.spring.scanner.ClassPathBeanDefinitionScannerAgent.getInstance($1) == null) {" +
+                    "    org.hotswap.agent.plugin.spring.scanner.ClassPathBeanDefinitionScannerAgent.getInstance(" +
+                            "(org.springframework.context.annotation.ClassPathBeanDefinitionScanner)this).registerBasePackage($1);" +
+                    "  }" +
                     "}");
 
-            LOGGER.debug("Class 'org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider' patched with basePackage registration.");
+            LOGGER.debug("Class 'org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider' " +
+                    "patched with basePackage registration.");
         } else {
-            LOGGER.debug("No need to register scanned path, instead just register 'spring.basePackagePrefix' in configuration file.");
+            LOGGER.debug("No need to register scanned path, instead just register 'spring.basePackagePrefix' in " +
+                    "configuration file.");
         }
     }
 }

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/SpringBeanTransformer.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/SpringBeanTransformer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.scanner;
+
+import org.hotswap.agent.command.Scheduler;
+import org.hotswap.agent.plugin.spring.SpringChangesAnalyzer;
+import org.hotswap.agent.util.HaClassFileTransformer;
+
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.ProtectionDomain;
+import java.util.Objects;
+
+public class SpringBeanTransformer implements HaClassFileTransformer {
+    private ClassLoader appClassLoader;
+    private Scheduler scheduler;
+    private String basePackage;
+
+    public SpringBeanTransformer(ClassLoader appClassLoader, Scheduler scheduler, String basePackage) {
+        this.appClassLoader = appClassLoader;
+        this.scheduler = scheduler;
+        this.basePackage = basePackage;
+    }
+
+    @Override
+    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
+                            ProtectionDomain protectionDomain,
+                            byte[] classfileBuffer) throws IllegalClassFormatException {
+        final SpringChangesAnalyzer analyzer = new SpringChangesAnalyzer(appClassLoader);
+        if (classBeingRedefined != null) {
+            if (analyzer.isReloadNeeded(classBeingRedefined, classfileBuffer)) {
+                scheduler.scheduleCommand(new ClassPathBeanRefreshCommand(classBeingRedefined.getClassLoader(),
+                        basePackage, className, classfileBuffer));
+            }
+        }
+        return classfileBuffer;
+    }
+
+    @Override
+    public boolean isForRedefinitionOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SpringBeanTransformer that = (SpringBeanTransformer) o;
+        return Objects.equals(appClassLoader, that.appClassLoader) && Objects.equals(basePackage, that.basePackage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(appClassLoader, basePackage);
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/SpringBeanWatchEventListener.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/SpringBeanWatchEventListener.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.scanner;
+
+import org.hotswap.agent.command.Scheduler;
+import org.hotswap.agent.logging.AgentLogger;
+import org.hotswap.agent.util.IOUtils;
+import org.hotswap.agent.util.classloader.ClassLoaderHelper;
+import org.hotswap.agent.watch.WatchEventListener;
+import org.hotswap.agent.watch.WatchFileEvent;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class SpringBeanWatchEventListener implements WatchEventListener {
+    private static final AgentLogger LOGGER = AgentLogger.getLogger(SpringBeanWatchEventListener.class);
+
+    /**
+     * If a class is modified in IDE, sequence of multiple events is generated -
+     * class file DELETE, CREATE, MODIFY, than Hotswap transformer is invoked.
+     * ClassPathBeanRefreshCommand tries to merge these events into single command.
+     * Wait this this timeout after class file event.
+     */
+    private static final int WAIT_ON_CREATE = 600;
+
+    private Scheduler scheduler;
+    private ClassLoader appClassLoader;
+    private String basePackage;
+
+    public SpringBeanWatchEventListener(Scheduler scheduler, ClassLoader appClassLoader, String basePackage) {
+        this.scheduler = scheduler;
+        this.appClassLoader = appClassLoader;
+        this.basePackage = basePackage;
+    }
+
+    @Override
+    public void onEvent(WatchFileEvent event) {
+        if (event.isFile() && event.getURI().toString().endsWith(".class")) {
+            // check that the class is not loaded by the classloader yet (avoid duplicate reload)
+            String className;
+            try {
+                className = IOUtils.urlToClassName(event.getURI());
+            } catch (IOException e) {
+                LOGGER.trace("Watch event on resource '{}' skipped, probably Ok because of delete/create event " +
+                        "sequence (compilation not finished yet).", e, event.getURI());
+                return;
+            }
+            if (!ClassLoaderHelper.isClassLoaded(appClassLoader, className)) {
+                // refresh spring only for new classes
+                scheduler.scheduleCommand(new ClassPathBeanRefreshCommand(appClassLoader,
+                        basePackage, className, event), WAIT_ON_CREATE);
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SpringBeanWatchEventListener that = (SpringBeanWatchEventListener) o;
+        return Objects.equals(appClassLoader, that.appClassLoader) && Objects.equals(basePackage, that.basePackage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(appClassLoader, basePackage);
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/XmlBeanDefinitionScannerAgent.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/XmlBeanDefinitionScannerAgent.java
@@ -89,7 +89,7 @@ public class XmlBeanDefinitionScannerAgent {
     public static void registerBean(String beanName, BeanDefinition beanDefinition) {
         XmlBeanDefinitionScannerAgent agent = findAgent(beanDefinition);
         if (agent == null) {
-            LOGGER.debug("cannot find registered XmlBeanDefinitionScannerAgent for bean {}", beanName);
+            LOGGER.trace("cannot find registered XmlBeanDefinitionScannerAgent for bean {}", beanName);
             return;
         }
 

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/utils/RegistryUtils.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/utils/RegistryUtils.java
@@ -1,0 +1,16 @@
+package org.hotswap.agent.plugin.spring.utils;
+
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.support.GenericApplicationContext;
+
+public class RegistryUtils {
+    public static DefaultListableBeanFactory maybeRegistryToBeanFactory(BeanDefinitionRegistry registry) {
+        if (registry instanceof DefaultListableBeanFactory) {
+            return (DefaultListableBeanFactory) registry;
+        } else if (registry instanceof GenericApplicationContext) {
+            return ((GenericApplicationContext) registry).getDefaultListableBeanFactory();
+        }
+        return null;
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/ConfigurationTest.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/ConfigurationTest.java
@@ -7,6 +7,7 @@ import org.hotswap.agent.plugin.spring.configuration.beans.Config;
 import org.hotswap.agent.plugin.spring.configuration.configs.Config1;
 import org.hotswap.agent.plugin.spring.configuration.configs.Config2;
 import org.hotswap.agent.plugin.spring.configuration.configs.Config3;
+import org.hotswap.agent.plugin.spring.reader.AnnotatedBeanDefinitionReaderAgent;
 import org.hotswap.agent.plugin.spring.scanner.ClassPathBeanDefinitionScannerAgent;
 import org.hotswap.agent.util.test.WaitHelper;
 import org.junit.Ignore;
@@ -66,13 +67,13 @@ public class ConfigurationTest {
         classPool.appendClassPath(new LoaderClassPath(Config.class.getClassLoader()));
         CtClass ctClass = classPool.getAndRename(swap.getName(), Config.class.getName());
 
-        ClassPathBeanDefinitionScannerAgent.reloadFlag = true;
+        AnnotatedBeanDefinitionReaderAgent.reloadFlag = true;
         Files.copy(new ByteArrayInputStream(ctClass.toBytecode()), config.getFile().toPath(),
                 StandardCopyOption.REPLACE_EXISTING);
         assertTrue(WaitHelper.waitForCommand(new WaitHelper.Command() {
             @Override
             public boolean result() throws Exception {
-                return !ClassPathBeanDefinitionScannerAgent.reloadFlag;
+                return !AnnotatedBeanDefinitionReaderAgent.reloadFlag;
             }
         }, 3000));
 

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/ConfigurationTest.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/ConfigurationTest.java
@@ -1,0 +1,80 @@
+package org.hotswap.agent.plugin.spring.configuration;
+
+import org.hotswap.agent.javassist.ClassPool;
+import org.hotswap.agent.javassist.CtClass;
+import org.hotswap.agent.javassist.LoaderClassPath;
+import org.hotswap.agent.plugin.spring.configuration.beans.Config;
+import org.hotswap.agent.plugin.spring.configuration.configs.Config1;
+import org.hotswap.agent.plugin.spring.configuration.configs.Config2;
+import org.hotswap.agent.plugin.spring.configuration.configs.Config3;
+import org.hotswap.agent.plugin.spring.scanner.ClassPathBeanDefinitionScannerAgent;
+import org.hotswap.agent.util.test.WaitHelper;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = Config.class)
+public class ConfigurationTest {
+    @Autowired
+    private ApplicationContext context;
+
+    private static final Resource config = new ClassPathResource(Config.class.getName().replace('.', '/') + ".class");
+
+    @Test
+    public void swapConfigClass() throws Exception {
+        // Config.class
+        assertFalse(context.containsBean("a"));
+        assertFalse(context.containsBean("b"));
+        assertFalse(context.containsBean("c"));
+        assertFalse(context.containsBean("A"));
+
+        // Config1.class -> Config.class
+        replaceConfig(Config1.class);
+        assertTrue(context.containsBean("a"));
+        assertTrue(context.containsBean("b"));
+
+        // Config2.class -> Config1.class
+        replaceConfig(Config2.class);
+        assertTrue(context.containsBean("a"));
+        assertTrue(context.containsBean("c"));
+        assertFalse(context.containsBean("b"));
+
+
+        // Config3.class -> Config2.class
+        replaceConfig(Config3.class);
+        assertTrue(context.containsBean("A"));
+        assertFalse(context.containsBean("a"));
+        assertFalse(context.containsBean("c"));
+    }
+
+    private void replaceConfig(Class<?> swap) throws Exception {
+        ClassPool classPool = new ClassPool();
+        classPool.appendClassPath(new LoaderClassPath(Config.class.getClassLoader()));
+        CtClass ctClass = classPool.getAndRename(swap.getName(), Config.class.getName());
+
+        ClassPathBeanDefinitionScannerAgent.reloadFlag = true;
+        Files.copy(new ByteArrayInputStream(ctClass.toBytecode()), config.getFile().toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+        assertTrue(WaitHelper.waitForCommand(new WaitHelper.Command() {
+            @Override
+            public boolean result() throws Exception {
+                return !ClassPathBeanDefinitionScannerAgent.reloadFlag;
+            }
+        }, 3000));
+
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/ConfigurationXmlTest.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/ConfigurationXmlTest.java
@@ -7,7 +7,7 @@ import org.hotswap.agent.plugin.spring.configuration.beans.Config;
 import org.hotswap.agent.plugin.spring.configuration.configs.Config1;
 import org.hotswap.agent.plugin.spring.configuration.configs.Config2;
 import org.hotswap.agent.plugin.spring.configuration.configs.Config3;
-import org.hotswap.agent.plugin.spring.reader.AnnotatedBeanDefinitionReaderAgent;
+import org.hotswap.agent.plugin.spring.scanner.ClassPathBeanDefinitionScannerAgent;
 import org.hotswap.agent.util.test.WaitHelper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,8 +26,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = Config.class)
-public class ConfigurationTest {
+@ContextConfiguration(locations = {"classpath:configuration.xml"})
+public class ConfigurationXmlTest {
     @Autowired
     private ApplicationContext context;
 
@@ -63,14 +63,15 @@ public class ConfigurationTest {
         classPool.appendClassPath(new LoaderClassPath(Config.class.getClassLoader()));
         CtClass ctClass = classPool.getAndRename(swap.getName(), Config.class.getName());
 
-        AnnotatedBeanDefinitionReaderAgent.reloadFlag = true;
+        ClassPathBeanDefinitionScannerAgent.reloadFlag = true;
         Files.copy(new ByteArrayInputStream(ctClass.toBytecode()), config.getFile().toPath(),
                 StandardCopyOption.REPLACE_EXISTING);
         assertTrue(WaitHelper.waitForCommand(new WaitHelper.Command() {
             @Override
             public boolean result() throws Exception {
-                return !AnnotatedBeanDefinitionReaderAgent.reloadFlag;
+                return !ClassPathBeanDefinitionScannerAgent.reloadFlag;
             }
         }, 3000));
     }
 }
+

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/beans/BeanA.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/beans/BeanA.java
@@ -1,0 +1,4 @@
+package org.hotswap.agent.plugin.spring.configuration.beans;
+
+public class BeanA {
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/beans/BeanB.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/beans/BeanB.java
@@ -1,0 +1,4 @@
+package org.hotswap.agent.plugin.spring.configuration.beans;
+
+public class BeanB {
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/beans/BeanC.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/beans/BeanC.java
@@ -1,0 +1,4 @@
+package org.hotswap.agent.plugin.spring.configuration.beans;
+
+public class BeanC {
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/beans/Config.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/beans/Config.java
@@ -1,0 +1,11 @@
+package org.hotswap.agent.plugin.spring.configuration.beans;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan
+public class Config {
+
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/beans/Config.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/beans/Config.java
@@ -1,11 +1,8 @@
 package org.hotswap.agent.plugin.spring.configuration.beans;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan
 public class Config {
 
 }

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config1.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config1.java
@@ -1,0 +1,21 @@
+package org.hotswap.agent.plugin.spring.configuration.configs;
+
+import org.hotswap.agent.plugin.spring.configuration.beans.BeanA;
+import org.hotswap.agent.plugin.spring.configuration.beans.BeanB;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan
+public class Config1 {
+    @Bean
+    public BeanA a() {
+        return new BeanA();
+    }
+
+    @Bean
+    public BeanB b() {
+        return new BeanB();
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config1.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config1.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan
 public class Config1 {
     @Bean
     public BeanA a() {

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config2.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config2.java
@@ -1,0 +1,21 @@
+package org.hotswap.agent.plugin.spring.configuration.configs;
+
+import org.hotswap.agent.plugin.spring.configuration.beans.BeanA;
+import org.hotswap.agent.plugin.spring.configuration.beans.BeanC;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan
+public class Config2 {
+    @Bean
+    public BeanA a() {
+        return new BeanA();
+    }
+
+    @Bean
+    public BeanC c() {
+        return new BeanC();
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config2.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config2.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan
 public class Config2 {
     @Bean
     public BeanA a() {

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config3.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config3.java
@@ -1,0 +1,15 @@
+package org.hotswap.agent.plugin.spring.configuration.configs;
+
+import org.hotswap.agent.plugin.spring.configuration.beans.BeanA;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan
+public class Config3 {
+    @Bean("A")
+    public BeanA a() {
+        return new BeanA();
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config3.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/configuration/configs/Config3.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan
 public class Config3 {
     @Bean("A")
     public BeanA a() {

--- a/plugin/hotswap-agent-spring-plugin/src/test/resources/configuration.xml
+++ b/plugin/hotswap-agent-spring-plugin/src/test/resources/configuration.xml
@@ -1,0 +1,8 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
+
+    <context:component-scan base-package="org.hotswap.agent.plugin.spring.configuration.beans"/>
+</beans>

--- a/plugin/hotswap-agent-spring-plugin/src/test/resources/hotswap-agent.properties
+++ b/plugin/hotswap-agent-spring-plugin/src/test/resources/hotswap-agent.properties
@@ -2,3 +2,4 @@
 LOGGER=warning
 LOGGER.org.hotswap.agent.plugin.spring=trace
 #spring.basePackagePrefix=org.hotswap
+autoHotswap=true


### PR DESCRIPTION
The current spring plugin doesn't have `@Configuration` support which's used quite popularly in today's modern spring app. 

a) Scenario#1: Declare component-scan in XML file, and there is a configuration class under the defined package.

```xml
<beans xmlns="http://www.springframework.org/schema/beans"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:context="http://www.springframework.org/schema/context"
       xsi:schemaLocation="http://www.springframework.org/schema/beans
    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">

    <context:component-scan base-package="org.hotswap.agent.plugin.spring.configuration.beans"/>
</beans>
```

```java
package org.hotswap.agent.plugin.spring.configuration.beans;

import org.springframework.context.annotation.Configuration;

@Configuration
public class Config {

}
```

b) Scneario#2: Instead of using XML, user starts to use AnnotationConfigApplicationContext or @ContextConfugration in unit test like this:


```java 
AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(Config.class);
```

```java
@RunWith(SpringJUnit4ClassRunner.class)
@ContextConfiguration(classes = Config.class)
public class ConfigurationTest {
}
```

This change makes configuration class hotswap work in the above scenarios.