### PR TITLE
potential deadlock

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/util/HotswapTransformer.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/util/HotswapTransformer.java
@@ -35,7 +35,6 @@ import java.util.WeakHashMap;
 import java.util.regex.Pattern;
 
 import org.hotswap.agent.annotation.handler.PluginClassFileTransformer;
-import org.hotswap.agent.command.Command;
 import org.hotswap.agent.config.PluginManager;
 import org.hotswap.agent.logging.AgentLogger;
 
@@ -316,18 +315,7 @@ public class HotswapTransformer implements ClassFileTransformer {
             } else {
                 // ensure the classloader should not be excluded
                 if (shouldScheduleClassLoader(classLoader)) {
-                    // schedule the excecution
-                    PluginManager.getInstance().getScheduler().scheduleCommand(new Command() {
-                        @Override
-                        public void executeCommand() {
-                            PluginManager.getInstance().initClassLoader(classLoader, protectionDomain);
-                        }
-
-                        @Override
-                        public String toString() {
-                            return "executeCommand: initClassLoader(" + classLoader + ")";
-                        }
-                    }, 1000);
+                    PluginManager.getInstance().initClassLoader(classLoader, protectionDomain);
                 }
             }
         }


### PR DESCRIPTION
I experienced a deadlock recently, which is shown below:

```
Found one Java-level deadlock:
=============================
"Thread-11":
  waiting to lock monitor 0x00007fab28008800 (object 0x00000006003b8eb0, a org.hotswap.agent.config.PluginManager),
  which is held by "Thread-44"
"Thread-44":
  waiting to lock monitor 0x00007fab5091b900 (object 0x000000060060b7b8, a c.t.p.CustomClassLoader),
  which is held by "Thread-11"

Java stack information for the threads listed above:
===================================================
"Thread-11":
	at org.hotswap.agent.config.PluginManager.initClassLoader(PluginManager.java:181)
	- waiting to lock <0x00000006003b8eb0> (a org.hotswap.agent.config.PluginManager)
	at org.hotswap.agent.annotation.handler.PluginClassFileTransformer.transform(PluginClassFileTransformer.java:173)
	at org.hotswap.agent.annotation.handler.PluginClassFileTransformer.transform(PluginClassFileTransformer.java:112)
	at org.hotswap.agent.util.HotswapTransformer.transform(HotswapTransformer.java:253)
	at java.lang.instrument.ClassFileTransformer.transform(java.instrument@11.0.15/ClassFileTransformer.java:246)
	at sun.instrument.TransformerManager.transform(java.instrument@11.0.15/TransformerManager.java:188)
	at sun.instrument.InstrumentationImpl.transform(java.instrument@11.0.15/InstrumentationImpl.java:563)
	at java.lang.ClassLoader.defineClass1(java.base@11.0.15/Native Method)
	at java.lang.ClassLoader.defineClass(java.base@11.0.15/ClassLoader.java:1017)
	at java.security.SecureClassLoader.defineClass(java.base@11.0.15/SecureClassLoader.java:174)
	at java.net.URLClassLoader.defineClass(java.base@11.0.15/URLClassLoader.java:555)
	at java.net.URLClassLoader$1.run(java.base@11.0.15/URLClassLoader.java:458)
	at java.net.URLClassLoader$1.run(java.base@11.0.15/URLClassLoader.java:452)
	at java.security.AccessController.doPrivileged(java.base@11.0.15/Native Method)
	at java.net.URLClassLoader.findClass(java.base@11.0.15/URLClassLoader.java:451)
	...
	- locked <0x000000060060b7b8> (a c.t.p.CustomClassLoader)
	...
	at c.t.p.CustomClassLoader.loadClass(CustomClassLoader.java:75)
	...
	at java.lang.Thread.run(java.base@11.0.15/Thread.java:829)
"Thread-44":
	at java.lang.ClassLoader.checkCerts(java.base@11.0.15/ClassLoader.java:1140)
	- waiting to lock <0x000000060060b7b8> (a c.t.p.CustomClassLoader)
	at java.lang.ClassLoader.preDefineClass(java.base@11.0.15/ClassLoader.java:906)
	at java.lang.ClassLoader.defineClass(java.base@11.0.15/ClassLoader.java:1015)
	at jdk.internal.reflect.GeneratedMethodAccessor1.invoke(java.base@11.0.15/Unknown Source)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@11.0.15/DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(java.base@11.0.15/Method.java:566)
	at org.hotswap.agent.javassist.util.proxy.DefineClassHelper$JavaOther.defineClass(DefineClassHelper.java:214)
	at org.hotswap.agent.javassist.util.proxy.DefineClassHelper$Java11.defineClass(DefineClassHelper.java:52)
	at org.hotswap.agent.javassist.util.proxy.DefineClassHelper.toClass(DefineClassHelper.java:263)
	at org.hotswap.agent.javassist.ClassPool.toClass(ClassPool.java:1232)
	at org.hotswap.agent.javassist.CtClass.toClass(CtClass.java:1398)
	at org.hotswap.agent.util.classloader.ClassLoaderDefineClassPatcher.patch(ClassLoaderDefineClassPatcher.java:93)
	at org.hotswap.agent.config.PluginManager.initClassLoader(PluginManager.java:186)
	- locked <0x00000006003b8eb0> (a org.hotswap.agent.config.PluginManager)
	at org.hotswap.agent.util.HotswapTransformer$1.executeCommand(HotswapTransformer.java:323)
	at org.hotswap.agent.command.impl.CommandExecutor.run(CommandExecutor.java:43)

Found 1 deadlock.
```

In this case, a class transformer, say 'FooTransformer', is added with `@OnClassLoadEvent(classNameRegexp = "c.t.Foo")` to enhance class "c.t.Foo", and this class "c.t.Foo" is loaded from the class loader 'c.t.p.CustomClassLoader'.

When the class 'c.t.Foo' is loaded from 'c.t.p.CustomClassLoader', org.hotswap.agent.util.HotswapTransformer#transform will be triggered and executed on 'Thread-11'.  Thread-11 holds the classloader (c.t.p.CustomClassLoader) lock, and tries to acquire the plugin manager lock at "line#3", but at the same time, Thread-11 schedules a task at "line#1" which can very likely hold the plugin manager's lock, and then acquire the classloader's lock which unfortunately has already been hold by 'Thread-11'.  

```java

// The current thread is Thread-11, before the code below is reached, it's already acquired classloader 'c.t.p.CustomClassLoader' lock.

// fork Thread-44, get PluginManager lock, and then wait for classloader 'c.t.p.CustomClassLoader' lock.
ensureClassLoaderInitialized(classLoader, protectionDomain);  // line#1
...
for(ClassFileTransformer transformer: pluginTransformers) { // line#2
    // PluginClassFileTransformer#transform() call pluginManager.initClassLoader(), and will try to acquire pluginManager's lock.
    result = transformer.transform(classLoader, className, redefiningClass, protectionDomain, result); // line#3
}

```

This change proposes a potential solution by simply removing the scheduling logic.
