### PR TITLE
support preInstantiateSingletons

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/XmlBeanDefinitionScannerAgent.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/scanner/XmlBeanDefinitionScannerAgent.java
@@ -278,6 +278,10 @@ public class XmlBeanDefinitionScannerAgent {
         invokeBeanFactoryPostProcessors(factory);
         addBeanPostProcessors(factory);
 
+        // It's necessary to call preInstantiateSingletons to create singleton beans eagerly since user's code may not
+        // call getBean to trigger the creation of singleton beans.
+        factory.preInstantiateSingletons();
+
         reloadFlag = false;
     }
 

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/init/FooBean.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/init/FooBean.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.xml.init;
+
+import org.springframework.beans.factory.InitializingBean;
+
+public class FooBean implements InitializingBean {
+    private int value;
+    private static int staticValue;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        staticValue = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    public static int getStaticValue() {
+        return staticValue;
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/init/InitTest.java
+++ b/plugin/hotswap-agent-spring-plugin/src/test/java/org/hotswap/agent/plugin/spring/xml/init/InitTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2023 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.spring.xml.init;
+
+import org.hotswap.agent.plugin.spring.scanner.XmlBeanDefinitionScannerAgent;
+import org.hotswap.agent.util.test.WaitHelper;
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class InitTest {
+    private static final Resource xmlFile1 = new ClassPathResource("initContext-1.xml");
+    private static final Resource xmlFile2 = new ClassPathResource("initContext-2.xml");
+
+
+    @Test
+    public void swapXmlTest() throws Exception {
+        ApplicationContext applicationContext = new ClassPathXmlApplicationContext("classpath:initContext-1.xml");
+        assertEquals(1, FooBean.getStaticValue());
+
+
+        XmlBeanDefinitionScannerAgent.reloadFlag = true;
+        Files.copy(xmlFile2.getFile().toPath(), xmlFile1.getFile().toPath(), StandardCopyOption.REPLACE_EXISTING);
+        assertTrue(WaitHelper.waitForCommand(new WaitHelper.Command() {
+            @Override
+            public boolean result() throws Exception {
+                return !XmlBeanDefinitionScannerAgent.reloadFlag;
+            }
+        }, 5000));
+
+        assertEquals(2, FooBean.getStaticValue());
+    }
+}

--- a/plugin/hotswap-agent-spring-plugin/src/test/resources/initContext-1.xml
+++ b/plugin/hotswap-agent-spring-plugin/src/test/resources/initContext-1.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+    <bean class="org.hotswap.agent.plugin.spring.xml.init.FooBean">
+        <property name="value" value="1"/>
+    </bean>
+</beans>

--- a/plugin/hotswap-agent-spring-plugin/src/test/resources/initContext-2.xml
+++ b/plugin/hotswap-agent-spring-plugin/src/test/resources/initContext-2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+    <bean class="org.hotswap.agent.plugin.spring.xml.init.FooBean">
+        <property name="value" value="2"/>
+    </bean>
+</beans>


### PR DESCRIPTION
This proposed change call  the code below to init singleton bean eagerly since user's code may not have chance to call getBean() again so that user's spring bean has no chance to be hotswaped even though its corresponding bean definition has already been updated.

```java
factory.preInstantiateSingletons();
```