### PR TITLE
fix: when using mac and jetbrain runtime, it will lose change event

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/TreeWatcherNIO.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/TreeWatcherNIO.java
@@ -98,7 +98,7 @@ public class TreeWatcherNIO extends AbstractNIO2Watcher {
      * @throws IOException Signals that an I/O exception has occurred.
      */
     @Override
-    protected void registerAll(Path dir) throws IOException {
+    protected void registerAll(Path dir, WatchEvent.Kind kind, boolean ignoreFile) throws IOException {
         LOGGER.info("Registering directory {} ", dir);
         register(dir);
     }

--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/WatcherNIO2.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/watch/nio/WatcherNIO2.java
@@ -51,7 +51,7 @@ public class WatcherNIO2 extends AbstractNIO2Watcher {
     }
 
     @Override
-    protected void registerAll(final Path dir) throws IOException {
+    protected void registerAll(final Path dir, WatchEvent.Kind kind, boolean ignoreFile) throws IOException {
         // register directory and sub-directories
         LOGGER.debug("Registering directory  {}", dir);
 
@@ -59,6 +59,18 @@ public class WatcherNIO2 extends AbstractNIO2Watcher {
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
                 register(dir);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (ignoreFile) {
+                    return FileVisitResult.CONTINUE;
+                }
+                if (kind != null) {
+                    LOGGER.debug("Dispatch event '{}' on '{}'", kind, file);
+                    dispatchEvent(kind, file);
+                }
                 return FileVisitResult.CONTINUE;
             }
         });


### PR DESCRIPTION
when use jdk version "[dcevm-11.0.15+1](https://github.com/TravaOpenJDK/trava-jdk-11-dcevm/releases)", it work well; when use [jetbrains runtime](https://github.com/JetBrains/JetBrainsRuntime/releases), it failed when one directory only contain one file.

If one package contains only one java file, the file is modified and recompiled in the intellij idea. 

When using dcevm-11.0.15+1, the events is as following:
```
HOTSWAP AGENT: 18:14:43.391 DEBUG (org.hotswap.agent.watch.nio.WatcherNIO2) - Watch event 'ENTRY_MODIFY' on '/Users/cvictory/workspace/hotswap/pandora-boot-demo-jdk11/pandora-boot-demo-jdk11-start/target/classes/com/alibaba/middleware' --> middleware
HOTSWAP AGENT: 18:14:43.391 DEBUG (org.hotswap.agent.watch.nio.WatcherNIO2) - Watch event 'ENTRY_MODIFY' on '/Users/cvictory/workspace/hotswap/pandora-boot-demo-jdk11/pandora-boot-demo-jdk11-start/target/classes/com/alibaba/middleware/hsf' --> hsf
HOTSWAP AGENT: 18:14:43.391 DEBUG (org.hotswap.agent.watch.nio.WatcherNIO2) - Watch event 'ENTRY_MODIFY' on '/Users/cvictory/workspace/hotswap/pandora-boot-demo-jdk11/pandora-boot-demo-jdk11-start/target/classes/com/alibaba/middleware/hsf/consumer' --> consumer
HOTSWAP AGENT: 18:14:43.392 DEBUG (org.hotswap.agent.watch.nio.WatcherNIO2) - Watch event 'ENTRY_MODIFY' on '/Users/cvictory/workspace/hotswap/pandora-boot-demo-jdk11/pandora-boot-demo-jdk11-start/target/classes/com/alibaba/middleware/hsf/consumer/HsfController.class' --> HsfController.class
```

When using jetbrains runtime, the events is as following:
```
HOTSWAP AGENT: 18:04:43.162 WARNING (org.hotswap.agent.watch.nio.WatcherNIO2) - Watcher on /Users/cvictory/workspace/hotswap/pandora-boot-demo-jdk11/pandora-boot-demo-jdk11-start/target/classes/com/alibaba/middleware/hsf/consumer not valid, removing path=
HOTSWAP AGENT: 18:04:43.164 WARNING (org.hotswap.agent.watch.nio.WatcherNIO2) - Watcher on /Users/cvictory/workspace/hotswap/pandora-boot-demo-jdk11/pandora-boot-demo-jdk11-start/target/classes/com/alibaba/middleware/hsf not valid, removing path=
HOTSWAP AGENT: 18:04:43.368 DEBUG (org.hotswap.agent.watch.nio.WatcherNIO2) - Watch event 'ENTRY_DELETE' on '/Users/cvictory/workspace/hotswap/pandora-boot-demo-jdk11/pandora-boot-demo-jdk11-start/target/classes/com/alibaba/middleware/hsf' --> hsf
HOTSWAP AGENT: 18:04:43.816 DEBUG (org.hotswap.agent.watch.nio.WatcherNIO2) - Watch event 'ENTRY_CREATE' on '/Users/cvictory/workspace/hotswap/pandora-boot-demo-jdk11/pandora-boot-demo-jdk11-start/target/classes/com/alibaba/middleware/hsf' --> hsf
HOTSWAP AGENT: 18:04:43.816 DEBUG (org.hotswap.agent.watch.nio.WatcherNIO2) - Registering directory  /Users/cvictory/workspace/hotswap/pandora-boot-demo-jdk11/pandora-boot-demo-jdk11-start/target/classes/com/alibaba/middleware/hsf
```
It lost the change event of '.class'  file.

So we should notify the class change when it is 'ENTRY_CREATE' event.


