### PR TITLE
fix: the ClassLoader of BeanFactory.class is not the same as the classLoader of bean

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/getbean/ProxyReplacer.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/getbean/ProxyReplacer.java
@@ -93,7 +93,10 @@ public class ProxyReplacer {
             } catch (ClassNotFoundException e) {
                 LOGGER.error("error adding org.springframework.core.InfrastructureProxy to proxy class", e);
             }
-            return Proxy.newProxyInstance(beanFactry.getClass().getClassLoader(), interfaces, handler);
+            // fix: it should be the classloader of the bean,
+            // or org.springframework.beans.factory.support.AbstractBeanFactory.getBeanClassLoader,
+            // but not the classLoader of the beanFactry
+            return Proxy.newProxyInstance(bean.getClass().getClassLoader(), interfaces, handler);
         } else if (EnhancerProxyCreater.isSupportedCglibProxy(bean)) {
             // already a proxy, skip..
             if (bean.getClass().getName().contains("$HOTSWAPAGENT_")) {


### PR DESCRIPTION
The right way is :  the classloader of the bean or org.springframework.beans.factory.support.AbstractBeanFactory.getBeanClassLoader, but not the classLoader of the beanFactry.class.  
