### PR TITLE
better naming for interfaces under o.h.a.p.spring.transformers.api

### DIFF
--- a/plugin/hotswap-agent-spring-boot-plugin/src/main/java/org/hotswap/agent/plugin/spring/boot/transformers/PropertySourceLoaderTransformer.java
+++ b/plugin/hotswap-agent-spring-boot-plugin/src/main/java/org/hotswap/agent/plugin/spring/boot/transformers/PropertySourceLoaderTransformer.java
@@ -137,8 +137,8 @@ public class PropertySourceLoaderTransformer {
     private static void enhanceBasePropertySourceLoader(CtClass clazz) throws CannotCompileException {
         clazz.addMethod(CtMethod.make("private void load0(org.springframework.core.env.PropertySource p, " +
                 "org.hotswap.agent.plugin.spring.api.PropertySourceReloader r) throws java.io.IOException { " +
-                "if (p instanceof org.hotswap.agent.plugin.spring.transformers.api.IReloadPropertySource) { " +
-                "((org.hotswap.agent.plugin.spring.transformers.api.IReloadPropertySource) p).setReload(r); " +
+                "if (p instanceof org.hotswap.agent.plugin.spring.transformers.api.ReloadablePropertySource) { " +
+                "((org.hotswap.agent.plugin.spring.transformers.api.ReloadablePropertySource) p).setReload(r); " +
                 "} }", clazz));
         clazz.addMethod(CtMethod.make("private void loadList0(java.util.List ps, " +
                 "org.hotswap.agent.plugin.spring.api.PropertySourceReloader r) throws java.io.IOException { " +

--- a/plugin/hotswap-agent-spring-boot-plugin/src/main/java/org/hotswap/agent/plugin/spring/boot/transformers/PropertySourceTransformer.java
+++ b/plugin/hotswap-agent-spring-boot-plugin/src/main/java/org/hotswap/agent/plugin/spring/boot/transformers/PropertySourceTransformer.java
@@ -44,7 +44,7 @@ public class PropertySourceTransformer {
     }
 
     private static void transformPropertySource(CtClass clazz, ClassPool classPool) throws NotFoundException, CannotCompileException {
-        clazz.addInterface(classPool.get("org.hotswap.agent.plugin.spring.transformers.api.IReloadPropertySource"));
+        clazz.addInterface(classPool.get("org.hotswap.agent.plugin.spring.transformers.api.ReloadablePropertySource"));
         clazz.addField(CtField.make("private org.hotswap.agent.plugin.spring.api.PropertySourceReloader reload;", clazz));
 
         clazz.addMethod(CtMethod.make("public void setReload(org.hotswap.agent.plugin.spring.api.PropertySourceReloader r) { this.reload = r; }", clazz));

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/core/BeanFactoryProcessor.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/core/BeanFactoryProcessor.java
@@ -19,13 +19,11 @@
 package org.hotswap.agent.plugin.spring.core;
 
 import org.hotswap.agent.logging.AgentLogger;
-import org.hotswap.agent.plugin.spring.transformers.api.IBeanFactoryLifecycle;
-import org.hotswap.agent.plugin.spring.transformers.api.IPlaceholderConfigurerSupport;
-import org.hotswap.agent.plugin.spring.utils.AnnotatedBeanDefinitionUtils;
+import org.hotswap.agent.plugin.spring.transformers.api.BeanFactoryLifecycle;
+import org.hotswap.agent.plugin.spring.transformers.api.ValueResolverSupport;
 import org.hotswap.agent.util.ReflectionHelper;
 import org.hotswap.agent.util.spring.util.ObjectUtils;
 import org.hotswap.agent.util.spring.util.ReflectionUtils;
-import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.PlaceholderConfigurerSupport;
@@ -34,7 +32,6 @@ import org.springframework.util.StringValueResolver;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.function.Predicate;
@@ -61,8 +58,8 @@ public class BeanFactoryProcessor {
      */
     public static void postProcessDestroySingleton(DefaultSingletonBeanRegistry beanFactory, String beanName) {
         LOGGER.info("destroy bean '{}' from '{}'", beanName, ObjectUtils.identityToString(beanFactory));
-        if (beanFactory instanceof IBeanFactoryLifecycle) {
-            ((IBeanFactoryLifecycle) beanFactory).hotswapAgent$destroyBean(beanName);
+        if (beanFactory instanceof BeanFactoryLifecycle) {
+            ((BeanFactoryLifecycle) beanFactory).hotswapAgent$destroyBean(beanName);
         }
     }
 
@@ -125,8 +122,8 @@ public class BeanFactoryProcessor {
 
     private static void resetEmbeddedValueResolvers(DefaultListableBeanFactory beanFactory, String beanName) {
         Object target = beanFactory.getSingleton(beanName);
-        if (target != null && target instanceof PlaceholderConfigurerSupport && target instanceof IPlaceholderConfigurerSupport) {
-            IPlaceholderConfigurerSupport placeholderConfigurerSupport = (IPlaceholderConfigurerSupport) target;
+        if (target != null && target instanceof PlaceholderConfigurerSupport && target instanceof ValueResolverSupport) {
+            ValueResolverSupport placeholderConfigurerSupport = (ValueResolverSupport) target;
             Field field = ReflectionUtils.findField(beanFactory.getClass(), "embeddedValueResolvers");
             if (field != null) {
                 ReflectionUtils.makeAccessible(field);

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/files/PropertyReload.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/files/PropertyReload.java
@@ -21,8 +21,8 @@ package org.hotswap.agent.plugin.spring.files;
 import org.hotswap.agent.logging.AgentLogger;
 import org.hotswap.agent.plugin.spring.core.BeanFactoryProcessor;
 import org.hotswap.agent.plugin.spring.listener.SpringEventSource;
-import org.hotswap.agent.plugin.spring.transformers.api.IReloadPropertySource;
-import org.hotswap.agent.plugin.spring.transformers.api.IResourcePropertySource;
+import org.hotswap.agent.plugin.spring.transformers.api.ReloadablePropertySource;
+import org.hotswap.agent.plugin.spring.transformers.api.ReloadableResourcePropertySource;
 import org.hotswap.agent.plugin.spring.utils.AnnotatedBeanDefinitionUtils;
 import org.hotswap.agent.util.ReflectionHelper;
 import org.hotswap.agent.util.spring.util.ObjectUtils;
@@ -110,15 +110,15 @@ public class PropertyReload {
 
     private static void doReloadPropertySource(MutablePropertySources propertySources) {
         for (PropertySource<?> propertySource : propertySources) {
-            if (propertySource instanceof IResourcePropertySource) {
+            if (propertySource instanceof ReloadableResourcePropertySource) {
                 try {
-                    ((IResourcePropertySource) propertySource).reloadPropertySource();
+                    ((ReloadableResourcePropertySource) propertySource).reload();
                 } catch (IOException e) {
                     LOGGER.error("reload property source error", e, propertySource.getName());
                 }
             }
-            if (propertySource instanceof IReloadPropertySource) {
-                ((IReloadPropertySource) propertySource).reload();
+            if (propertySource instanceof ReloadablePropertySource) {
+                ((ReloadablePropertySource) propertySource).reload();
             }
         }
     }

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reload/BeanFactoryAssistant.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reload/BeanFactoryAssistant.java
@@ -18,7 +18,7 @@
  */
 package org.hotswap.agent.plugin.spring.reload;
 
-import org.hotswap.agent.plugin.spring.transformers.api.IBeanFactoryLifecycle;
+import org.hotswap.agent.plugin.spring.transformers.api.BeanFactoryLifecycle;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
 import java.util.Map;
@@ -83,8 +83,8 @@ public class BeanFactoryAssistant {
      * @return
      */
     public boolean isDestroyedBean(String beanName) {
-        if (beanFactory instanceof IBeanFactoryLifecycle) {
-            return ((IBeanFactoryLifecycle) beanFactory).hotswapAgent$isDestroyedBean(beanName);
+        if (beanFactory instanceof BeanFactoryLifecycle) {
+            return ((BeanFactoryLifecycle) beanFactory).hotswapAgent$isDestroyedBean(beanName);
         }
         return false;
     }

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reload/SpringBeanReload.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reload/SpringBeanReload.java
@@ -24,7 +24,7 @@ import org.hotswap.agent.plugin.spring.files.PropertyReload;
 import org.hotswap.agent.plugin.spring.files.XmlBeanDefinitionScannerAgent;
 import org.hotswap.agent.plugin.spring.getbean.ProxyReplacer;
 import org.hotswap.agent.plugin.spring.listener.SpringEventSource;
-import org.hotswap.agent.plugin.spring.transformers.api.IBeanFactoryLifecycle;
+import org.hotswap.agent.plugin.spring.transformers.api.BeanFactoryLifecycle;
 import org.hotswap.agent.plugin.spring.utils.ResourceUtils;
 import org.hotswap.agent.util.AnnotationHelper;
 import org.hotswap.agent.util.spring.util.ClassUtils;
@@ -532,8 +532,8 @@ public class SpringBeanReload {
     private void clearLocalCache() {
         beansToProcess.clear();
         newBeanNames.clear();
-        if (beanFactory instanceof IBeanFactoryLifecycle) {
-            ((IBeanFactoryLifecycle) beanFactory).hotswapAgent$clearDestroyBean();
+        if (beanFactory instanceof BeanFactoryLifecycle) {
+            ((BeanFactoryLifecycle) beanFactory).hotswapAgent$clearDestroyBean();
         }
     }
 

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/BeanFactoryTransformer.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/BeanFactoryTransformer.java
@@ -31,7 +31,7 @@ public class BeanFactoryTransformer {
     @OnClassLoadEvent(classNameRegexp = "org.springframework.beans.factory.support.DefaultSingletonBeanRegistry")
     public static void registerDefaultSingletonBeanRegistry(ClassLoader appClassLoader, CtClass clazz, ClassPool classPool) throws NotFoundException, CannotCompileException {
         clazz.addField(CtField.make("private java.util.Set hotswapAgent$destroyBean = new java.util.HashSet();", clazz));
-        clazz.addInterface(classPool.get("org.hotswap.agent.plugin.spring.transformers.api.IBeanFactoryLifecycle"));
+        clazz.addInterface(classPool.get("org.hotswap.agent.plugin.spring.transformers.api.BeanFactoryLifecycle"));
         clazz.addMethod(CtNewMethod.make("public boolean hotswapAgent$isDestroyedBean(String beanName) { return hotswapAgent$destroyBean.contains(beanName); }", clazz));
         clazz.addMethod(CtNewMethod.make("public void hotswapAgent$destroyBean(String beanName) { hotswapAgent$destroyBean.add(beanName); }", clazz));
         clazz.addMethod(CtNewMethod.make("public void hotswapAgent$clearDestroyBean() { hotswapAgent$destroyBean.clear(); }", clazz));

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/PlaceholderConfigurerSupportTransformer.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/PlaceholderConfigurerSupportTransformer.java
@@ -18,11 +18,11 @@ public class PlaceholderConfigurerSupportTransformer {
     @OnClassLoadEvent(classNameRegexp = "org.springframework.beans.factory.config.PlaceholderConfigurerSupport")
     public static void transform(CtClass clazz, ClassPool classPool) throws NotFoundException, CannotCompileException {
         for (CtClass interfaceClazz : clazz.getInterfaces()) {
-            if (interfaceClazz.getName().equals("org.hotswap.agent.plugin.spring.transformers.api.IPlaceholderConfigurerSupport")) {
+            if (interfaceClazz.getName().equals("org.hotswap.agent.plugin.spring.transformers.api.ValueResolverSupport")) {
                 return;
             }
         }
-        clazz.addInterface(classPool.get("org.hotswap.agent.plugin.spring.transformers.api.IPlaceholderConfigurerSupport"));
+        clazz.addInterface(classPool.get("org.hotswap.agent.plugin.spring.transformers.api.ValueResolverSupport"));
         clazz.addField(CtField.make("private java.util.List _resolvers;", clazz), "new java.util.ArrayList(2)");
         clazz.addMethod(CtMethod.make("public java.util.List valueResolvers() { return this._resolvers; }", clazz));
         CtMethod ctMethod = clazz.getDeclaredMethod("doProcessProperties", new CtClass[]{classPool.get("org.springframework.beans.factory.config.ConfigurableListableBeanFactory"),

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/ResourcePropertySourceTransformer.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/ResourcePropertySourceTransformer.java
@@ -18,7 +18,7 @@ public class ResourcePropertySourceTransformer {
      */
     @OnClassLoadEvent(classNameRegexp = "org.springframework.core.io.support.ResourcePropertySource")
     public static void transform(CtClass clazz, ClassPool classPool) throws NotFoundException, CannotCompileException {
-        clazz.addInterface(classPool.get("org.hotswap.agent.plugin.spring.transformers.api.IResourcePropertySource"));
+        clazz.addInterface(classPool.get("org.hotswap.agent.plugin.spring.transformers.api.ReloadableResourcePropertySource"));
         clazz.addField(CtField.make("private org.springframework.core.io.support.EncodedResource encodedResource;", clazz));
         clazz.addField(CtField.make("private org.springframework.core.io.Resource resource;", clazz));
         CtConstructor ctConstructor0 = clazz.getDeclaredConstructor(new CtClass[]{classPool.get("java.lang.String"),

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/api/BeanFactoryLifecycle.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/api/BeanFactoryLifecycle.java
@@ -1,6 +1,6 @@
 package org.hotswap.agent.plugin.spring.transformers.api;
 
-public interface IBeanFactoryLifecycle {
+public interface BeanFactoryLifecycle {
 
     void hotswapAgent$destroyBean(String beanName);
 

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/api/ReloadablePropertySource.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/api/ReloadablePropertySource.java
@@ -20,7 +20,7 @@ package org.hotswap.agent.plugin.spring.transformers.api;
 
 import org.hotswap.agent.plugin.spring.api.PropertySourceReloader;
 
-public interface IReloadPropertySource {
+public interface ReloadablePropertySource {
 
     void setReload(PropertySourceReloader r);
 

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/api/ReloadableResourcePropertySource.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/api/ReloadableResourcePropertySource.java
@@ -9,13 +9,13 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
 
-public interface IResourcePropertySource {
+public interface ReloadableResourcePropertySource {
 
     EncodedResource encodedResource();
 
     Resource resource();
 
-    default boolean reloadPropertySource() throws IOException {
+    default boolean reload() throws IOException {
         Properties properties = null;
         if (encodedResource() != null) {
             properties = PropertiesLoaderUtils.loadProperties(encodedResource());

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/api/ValueResolverSupport.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/transformers/api/ValueResolverSupport.java
@@ -4,7 +4,7 @@ import org.springframework.util.StringValueResolver;
 
 import java.util.List;
 
-public interface IPlaceholderConfigurerSupport {
+public interface ValueResolverSupport {
 
     List<StringValueResolver> valueResolvers();
 }


### PR DESCRIPTION
This change proposes a better naming for interfaces under o.h.a.p.spring.transformers.api:

* IBeanFactoryLifecycle
* IReloadPropertySource
* IResourcePropertySource
* IPlaceholderConfigurerSupport