### PR TITLE
fix #530, fix noSuchMethod in spring6

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/core/AutowiredAnnotationProcessor.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/core/AutowiredAnnotationProcessor.java
@@ -1,9 +1,11 @@
 package org.hotswap.agent.plugin.spring.core;
 
 import org.hotswap.agent.logging.AgentLogger;
+import org.springframework.beans.PropertyValues;
 import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 public class AutowiredAnnotationProcessor {
@@ -11,20 +13,39 @@ public class AutowiredAnnotationProcessor {
 
     public static void processSingletonBeanInjection(DefaultListableBeanFactory beanFactory) {
         try {
-            Map<String, AutowiredAnnotationBeanPostProcessor> postProcessors = beanFactory.getBeansOfType(AutowiredAnnotationBeanPostProcessor.class);
-            if (postProcessors == null || postProcessors.isEmpty()) {
+            Map<String, AutowiredAnnotationBeanPostProcessor> postProcessors = beanFactory.getBeansOfType(
+                AutowiredAnnotationBeanPostProcessor.class);
+            if (postProcessors.isEmpty()) {
                 LOGGER.debug("AutowiredAnnotationProcessor not exist");
                 return;
             }
             AutowiredAnnotationBeanPostProcessor postProcessor = postProcessors.values().iterator().next();
+            boolean postProcessPropertyValuesNotExists = false;
             for (String beanName : beanFactory.getBeanDefinitionNames()) {
                 Object object = beanFactory.getSingleton(beanName);
                 if (object != null) {
-                    postProcessor.postProcessPropertyValues(null, null, object, beanName);
+                    if (postProcessPropertyValuesNotExists) {
+                        // spring 6.x
+                        postProcessor.postProcessProperties(null, object, beanName);
+                        continue;
+                    }
+                    try {
+                        // from spring 3.2.x to 5.x
+                        postProcessor.postProcessPropertyValues(null, null, object, beanName);
+                    } catch (NoSuchMethodError e) {
+                        // spring 6.x
+                        postProcessor.postProcessProperties(null, object, beanName);
+                        postProcessPropertyValuesNotExists = true;
+                    }
                 }
             }
-        } catch (Exception e) {
-            LOGGER.debug("AutowiredAnnotationProcessor maybe not exist", e);
+        } catch (Throwable e) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("AutowiredAnnotationProcessor maybe not exist", e);
+            } else {
+                LOGGER.warning("AutowiredAnnotationProcessor maybe not exist : " + e.getMessage());
+            }
         }
     }
+
 }


### PR DESCRIPTION
#530 

The org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor#postProcessPropertyValues is removed in spring6, we should use org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor#postProcessProperties to replace it. 