### PR TITLE
If we configure excludedClassLoaderPatterns, maybe we should skip transform

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/util/HotswapTransformer.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/util/HotswapTransformer.java
@@ -247,12 +247,12 @@ public class HotswapTransformer implements ClassFileTransformer {
         // ensure classloader initialized
        if (!ensureClassLoaderInitialized(classLoader, protectionDomain)) {
            // when classLoader is in excluded list, skip the transform
-           LOGGER.debug("Skipping classloader '{}' transform", classLoader);
+           LOGGER.trace("Skipping className '{}' classloader '{}' transform", className, classLoader);
            return bytes;
        }
 
         if(toApply.isEmpty() && pluginTransformers.isEmpty()) {
-            LOGGER.trace("No transformers defing for {} ", className);
+            LOGGER.trace("No transformers define for {} ", className);
             return bytes;
         }
 


### PR DESCRIPTION
I'm running into an issue: 
If a classLoader is excluded that configured as excludedClassLoaderPatterns, I expect that all the class of this ClassLoader will not be transformed,  but I find the classes that annotated as @OnClassLoadEvent are transformed.

I want to accomplish the goal above, so I post this pr, but I'm not sure if it's the right,  especially if it has any impact on others.