### PR TITLE
Fix the issue with MyBatis-Spring integration where MyBatis reloading is not functioning properly and results in a NullPointerException.

### DIFF
--- a/plugin/hotswap-agent-mybatis-plugin/src/main/java/org/hotswap/agent/plugin/mybatis/MyBatisRefreshCommands.java
+++ b/plugin/hotswap-agent-mybatis-plugin/src/main/java/org/hotswap/agent/plugin/mybatis/MyBatisRefreshCommands.java
@@ -42,9 +42,17 @@ public class MyBatisRefreshCommands {
 
     public static void reloadConfiguration() {
         LOGGER.debug("Refreshing MyBatis configuration.");
-        ConfigurationProxy.refreshProxiedConfigurations();
-        SpringMybatisConfigurationProxy.refreshProxiedConfigurations();
-        LOGGER.reload("MyBatis configuration refreshed.");
+        /**
+         * If running in MyBatis-Spring mode, then during reload, we only need to use SpringMybatisConfigurationProxy
+         * for reloading. Refreshing the ConfigurationProxy is not meaningful.The same applies in the opposite case.
+         */
+        if (SpringMybatisConfigurationProxy.runningBySpringMybatis()) {
+            SpringMybatisConfigurationProxy.refreshProxiedConfigurations();
+            LOGGER.debug("MyBatis Spring configuration refreshed.");
+        } else {
+            ConfigurationProxy.refreshProxiedConfigurations();
+            LOGGER.reload("MyBatis configuration refreshed.");
+        }
         reloadFlag = false;
     }
 }

--- a/plugin/hotswap-agent-mybatis-plugin/src/main/java/org/hotswap/agent/plugin/mybatis/proxy/ConfigurationProxy.java
+++ b/plugin/hotswap-agent-mybatis-plugin/src/main/java/org/hotswap/agent/plugin/mybatis/proxy/ConfigurationProxy.java
@@ -27,6 +27,7 @@ import org.apache.ibatis.builder.xml.XMLConfigBuilder;
 import org.apache.ibatis.session.Configuration;
 import org.hotswap.agent.javassist.util.proxy.MethodHandler;
 import org.hotswap.agent.javassist.util.proxy.ProxyFactory;
+import org.hotswap.agent.logging.AgentLogger;
 import org.hotswap.agent.plugin.mybatis.transformers.MyBatisTransformers;
 import org.hotswap.agent.util.ReflectionHelper;
 
@@ -36,9 +37,21 @@ import org.hotswap.agent.util.ReflectionHelper;
  * @author Vladimir Dvorak
  */
 public class ConfigurationProxy {
+
+    private static AgentLogger LOGGER = AgentLogger.getLogger(ConfigurationProxy.class);
+
     private static Map<XMLConfigBuilder, ConfigurationProxy> proxiedConfigurations = new HashMap<>();
 
     public static ConfigurationProxy getWrapper(XMLConfigBuilder configBuilder) {
+        /*
+         * MyBatis runs in MyBatis-Spring mode, so there is no need to cache configuration-related data.
+         * The related reload operations are handled by SpringMybatisConfigurationProxy
+         */
+        if (SpringMybatisConfigurationProxy.runningBySpringMybatis()) {
+            LOGGER.debug("MyBatis runs in MyBatis-Spring mode, so there is no need to cache configuration-related data");
+            return new ConfigurationProxy(configBuilder);
+        }
+        
         if (!proxiedConfigurations.containsKey(configBuilder)) {
             proxiedConfigurations.put(configBuilder, new ConfigurationProxy(configBuilder));
         }

--- a/plugin/hotswap-agent-mybatis-plugin/src/main/java/org/hotswap/agent/plugin/mybatis/proxy/SpringMybatisConfigurationProxy.java
+++ b/plugin/hotswap-agent-mybatis-plugin/src/main/java/org/hotswap/agent/plugin/mybatis/proxy/SpringMybatisConfigurationProxy.java
@@ -3,6 +3,7 @@ package org.hotswap.agent.plugin.mybatis.proxy;
 import org.apache.ibatis.session.Configuration;
 import org.hotswap.agent.javassist.util.proxy.MethodHandler;
 import org.hotswap.agent.javassist.util.proxy.ProxyFactory;
+import org.hotswap.agent.plugin.mybatis.transformers.ConfigurationCaller;
 import org.hotswap.agent.util.ReflectionHelper;
 
 import java.lang.reflect.Method;
@@ -24,10 +25,16 @@ public class SpringMybatisConfigurationProxy {
         return proxiedConfigurations.get(sqlSessionFactoryBean);
     }
 
+    public static boolean runningBySpringMybatis() {
+        return !proxiedConfigurations.isEmpty();
+    }
+
     public static void refreshProxiedConfigurations() {
         for (SpringMybatisConfigurationProxy wrapper : proxiedConfigurations.values())
             try {
+                ConfigurationCaller.setInReload(wrapper.configuration, true);
                 wrapper.refreshProxiedConfiguration();
+                ConfigurationCaller.setInReload(wrapper.configuration, false);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/plugin/hotswap-agent-mybatis-plugin/src/main/java/org/hotswap/agent/plugin/mybatis/transformers/ConfigurationCaller.java
+++ b/plugin/hotswap-agent-mybatis-plugin/src/main/java/org/hotswap/agent/plugin/mybatis/transformers/ConfigurationCaller.java
@@ -1,0 +1,19 @@
+package org.hotswap.agent.plugin.mybatis.transformers;
+
+import org.apache.ibatis.session.Configuration;
+import org.hotswap.agent.util.ReflectionHelper;
+
+public class ConfigurationCaller {
+    /**
+     * Sets the value of the $$ha$inReload field in the given MyBatis configuration.
+     * This field is used to determine if the configuration is in reload status.
+     *
+     * @param configuration The MyBatis configuration object to be modified.
+     * @param val           The value to set for the $$ha$inReload field. If true,
+     *                      the configuration will be marked as being in reload status.
+     */
+    public static void setInReload(Configuration configuration, boolean val) {
+        // Use ReflectionHelper to set the value of the $$ha$inReload field in the configuration object.
+        ReflectionHelper.set(configuration, MyBatisTransformers.IN_RELOAD_FIELD, val);
+    }
+}


### PR DESCRIPTION
### Fixes
- When MyBatis runs in Spring-MyBatis mode, it encounters a NullPointerException and the reload fails.[#556](https://github.com/HotswapProjects/HotswapAgent/issues/556)，[#550](https://github.com/HotswapProjects/HotswapAgent/issues/550),，[#538](https://github.com/HotswapProjects/HotswapAgent/issues/538),
- When MyBatis runs in Spring-MyBatis mode,there is no need to cache configuration-related data。The related reload operations are handled by SpringMybatisConfigurationProxy
- When MyBatis runs in Spring-MyBatis mode,we only need to use SpringMybatisConfigurationProxy for reloading. Refreshing the ConfigurationProxy is not meaningful.The same applies in the opposite case.