### PR TITLE
fix: tomcat major version detection

### DIFF
--- a/plugin/hotswap-agent-tomcat-plugin/pom.xml
+++ b/plugin/hotswap-agent-tomcat-plugin/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>hotswap-agent-tomcat-plugin</artifactId>
     
     <properties>
-        <tomcat.version>8.5.24</tomcat.version>
+        <tomcat.version>10.1.28</tomcat.version>
         <!--<tomcat.artifact>catalina</tomcat.artifact> &lt;!&ndash; catalina if 6.x &ndash;&gt;-->
         <!--tomcat-catalina if 7.x+ -->
          <tomcat.artifact>tomcat-catalina</tomcat.artifact>

--- a/plugin/hotswap-agent-tomcat-plugin/src/main/java/org/hotswap/agent/plugin/tomcat/TomcatPlugin.java
+++ b/plugin/hotswap-agent-tomcat-plugin/src/main/java/org/hotswap/agent/plugin/tomcat/TomcatPlugin.java
@@ -47,7 +47,7 @@ import java.util.Set;
  */
 @Plugin(name = "Tomcat", description = "Catalina based servlet containers.",
         testedVersions = {"7.0.50"},
-        expectedVersions = {"6x","7x", "8x", "9.x"},
+        expectedVersions = {"6x","7x", "8x", "9.x", "10.x"},
         supportClass = {WebappLoaderTransformer.class}
 )
 public class TomcatPlugin {
@@ -316,7 +316,7 @@ public class TomcatPlugin {
      */
     private static int resolveTomcatMajorVersion(String version) {
         try {
-            return Integer.valueOf(version.substring(0, 1));
+            return Integer.valueOf(version.split("\\.")[0]);
         } catch (Exception e) {
             LOGGER.debug("Unable to resolve server main version from version string {}", e, version);
             // assume latest known version


### PR DESCRIPTION
### This PR fixes the detection of the Tomcat major version in the Hotswap Agent plugin.

#### Main Changes:

- **Updated Tomcat Version**: The pom.xml for the Tomcat plugin has been updated to use Tomcat version 10.1.28, aligning the plugin with the latest versions of Tomcat.

- **Fix for Tomcat Version Detection:** The method resolveTomcatMajorVersion in `TomcatPlugin.java` has been adjusted to correctly detect the major version of Tomcat by using `split("\\.")` instead of `substring(0, 1)`. This change allows proper handling of multi-digit versions like `10.x`.


**Justification**:


- **Compatibility with Tomcat 10.x**: This update ensures that the Hotswap Agent plugin properly supports Tomcat 10.x, which is essential for projects that have migrated to the latest Tomcat versions.

- **Improved Version Handling Logic**: The previous implementation assumed the major version would be a single digit (e.g., `7.x, 8.x, 9.x`), which caused issues with two-digit versions like `10.x`. The new implementation addresses this limitation.


**Testing**

Tested locally with Tomcat `10.1.28`, confirming that the plugin correctly detects the Tomcat version and functions as expected.