### PR TITLE
Spring Plugin: use AbstractBeanDefinitionReader#getRegistry instead of AbstractBeanDefinitionReader#getBeanFactory

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/files/XmlBeanDefinitionScannerAgent.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/files/XmlBeanDefinitionScannerAgent.java
@@ -96,8 +96,8 @@ public class XmlBeanDefinitionScannerAgent {
      */
     public static void registerXmlBeanDefinitionScannerAgent(XmlBeanDefinitionReader reader, Resource resource) {
         LOGGER.trace("registerXmlBeanDefinitionScannerAgent, reader: {}, resource: {}, beanFactory:{}", reader,
-                resource, ObjectUtils.identityToString(reader.getBeanFactory()));
-        BeanDefinitionRegistry beanDefinitionRegistry = reader.getBeanFactory();
+                resource, ObjectUtils.identityToString(reader.getRegistry()));
+        BeanDefinitionRegistry beanDefinitionRegistry = reader.getRegistry();
         if (beanDefinitionRegistry instanceof DefaultListableBeanFactory) {
             DefaultListableBeanFactory defaultListableBeanFactory = (DefaultListableBeanFactory) beanDefinitionRegistry;
             Map<String, XmlBeanDefinitionScannerAgent> agentMap = beanFactoryToAgentMap.computeIfAbsent(defaultListableBeanFactory, k -> new HashMap<>());


### PR DESCRIPTION
Spring Plugin: use AbstractBeanDefinitionReader#getRegistry instead of AbstractBeanDefinitionReader#getBeanFactory which is deprecated in Spring Framework 6.0