### PR TITLE
fix non mybatisplus project SqlSessionFactoryBuilder transform twice issue

### DIFF
--- a/plugin/hotswap-agent-mybatis-plus-plugin/src/main/java/org/hotswap/agent/plugin/mybatisplus/transformers/MyBatisPlusTransformers.java
+++ b/plugin/hotswap-agent-mybatis-plus-plugin/src/main/java/org/hotswap/agent/plugin/mybatisplus/transformers/MyBatisPlusTransformers.java
@@ -136,7 +136,9 @@ public class MyBatisPlusTransformers {
 
     @OnClassLoadEvent(classNameRegexp = "org.apache.ibatis.session.SqlSessionFactoryBuilder")
     public static void patchSqlSessionFactoryBuilder(CtClass ctClass, ClassPool classPool) throws NotFoundException, CannotCompileException {
-        MyBatisRefreshCommands.isMybatisPlus = true;
+        if(!MyBatisRefreshCommands.isMybatisPlus){
+            return;
+        }
         addBuilderField(ctClass, classPool);
         CtMethod buildMethod = ctClass.getDeclaredMethod("build",
                 new CtClass[] {classPool.get("org.apache.ibatis.session.Configuration")});


### PR DESCRIPTION
running mybatis project throw exception 
Caused by: org.hotswap.agent.javassist.bytecode.DuplicateMemberException: duplicate field: $$ha$factoryBean
	at org.hotswap.agent.javassist.bytecode.ClassFile.testExistingField(ClassFile.java:677)
	at org.hotswap.agent.javassist.bytecode.ClassFile.addField(ClassFile.java:657)
	at org.hotswap.agent.javassist.CtClassType.addField(CtClassType.java:1432)
	at org.hotswap.agent.javassist.CtClass.addField(CtClass.java:1117)
	at org.hotswap.agent.plugin.mybatisplus.transformers.MyBatisPlusTransformers.addBuilderField(MyBatisPlusTransformers.java:127)
	at org.hotswap.agent.plugin.mybatisplus.transformers.MyBatisPlusTransformers.patchSqlSessionFactoryBuilder(MyBatisPlusTransformers.java:140)
	... 78 more
