### PR TITLE
use Versions annotation to specify the version of Spring in which the enhancements are enabled

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/SpringPlugin.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/SpringPlugin.java
@@ -72,7 +72,7 @@ import org.hotswap.agent.watch.Watcher;
  * @author Jiri Bubnik
  */
 @Plugin(name = "Spring", description = "Reload Spring configuration after class definition/change.",
-        testedVersions = {"All between 3.0.1 - 5.2.2"}, expectedVersions = {"3x", "4x", "5x"},
+        testedVersions = {"All between 3.1.0 - 5.3.30"}, expectedVersions = {"3x", "4x", "5x"},
         supportClass = {ClassPathBeanDefinitionScannerTransformer.class,
                 ProxyReplacerTransformer.class,
                 ConfigurationClassPostProcessorTransformer.class,
@@ -82,9 +82,8 @@ import org.hotswap.agent.watch.Watcher;
                 PostProcessorRegistrationDelegateTransformer.class,
                 BeanFactoryTransformer.class,
                 InitDestroyAnnotationBeanPostProcessorTransformer.class})
-@Versions(manifest = {@Manifest(value = "[3.0,6.0)", versionName= Name.ImplementationVersion, names={
-        @Name(key=Name.ImplementationTitle,value="spring-core"),
-})})
+@Versions(manifest = {@Manifest(value = "[3.1.0,)", versionName= Name.ImplementationVersion, names={
+        @Name(key=Name.ImplementationTitle,value="spring-core")})})
 public class SpringPlugin {
     private static final AgentLogger LOGGER = AgentLogger.getLogger(SpringPlugin.class);
 

--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/SpringPlugin.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/SpringPlugin.java
@@ -28,9 +28,12 @@ import java.util.List;
 import org.hotswap.agent.annotation.FileEvent;
 import org.hotswap.agent.annotation.Init;
 import org.hotswap.agent.annotation.LoadEvent;
+import org.hotswap.agent.annotation.Manifest;
+import org.hotswap.agent.annotation.Name;
 import org.hotswap.agent.annotation.OnClassLoadEvent;
 import org.hotswap.agent.annotation.OnResourceFileEvent;
 import org.hotswap.agent.annotation.Plugin;
+import org.hotswap.agent.annotation.Versions;
 import org.hotswap.agent.command.Scheduler;
 import org.hotswap.agent.config.PluginConfiguration;
 import org.hotswap.agent.javassist.CannotCompileException;
@@ -79,6 +82,9 @@ import org.hotswap.agent.watch.Watcher;
                 PostProcessorRegistrationDelegateTransformer.class,
                 BeanFactoryTransformer.class,
                 InitDestroyAnnotationBeanPostProcessorTransformer.class})
+@Versions(manifest = {@Manifest(value = "[3.0,6.0)", versionName= Name.ImplementationVersion, names={
+        @Name(key=Name.ImplementationTitle,value="spring-core"),
+})})
 public class SpringPlugin {
     private static final AgentLogger LOGGER = AgentLogger.getLogger(SpringPlugin.class);
 


### PR DESCRIPTION
The Spring plugin is not compatible with the versions before 3.1.0（See run-tests.sh of SpringPlugin） So why not use the Versions annotation to specify the version of Spring in which the enhancements are enabled? 

By the way, for Spring 6.x, the Spring CGLIB name policy has changed. Thus,  org.hotswap.agent.plugin.spring.getbean.ProxyReplacer#register is not compatible with the versions after 6.0.

see org.springframework.cglib.core.SpringNamingPolicy#SPRING_LABEL

```java
/**
/*
 * Copyright 2002-2023 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

package org.springframework.cglib.core;

/**
 * Custom variant of CGLIB's {@link DefaultNamingPolicy}, modifying the tag
 * in generated class names from "EnhancerByCGLIB" etc to a "SpringCGLIB" tag
 * and using a plain counter suffix instead of a hash code suffix (as of 6.0).
 *
 * <p>This allows for reliably discovering pre-generated Spring proxy classes
 * in the classpath.
 *
 * @author Juergen Hoeller
 * @author Sam Brannen
 * @since 3.2.8 / 6.0
 */
public final class SpringNamingPolicy implements NamingPolicy {

	public static final SpringNamingPolicy INSTANCE = new SpringNamingPolicy();

	private static final String SPRING_LABEL = "$$SpringCGLIB$$";

	private static final String FAST_CLASS_SUFFIX = "FastClass$$";


	private SpringNamingPolicy() {
	}

	@Override
	public String getClassName(String prefix, String source, Object key, Predicate names) {
		if (prefix == null) {
			prefix = "org.springframework.cglib.empty.Object";
		}
		else if (prefix.startsWith("java.") || prefix.startsWith("javax.")) {
			prefix = "_" + prefix;
		}

		String base;
		int existingLabel = prefix.indexOf(SPRING_LABEL);
		if (existingLabel >= 0) {
			base = prefix.substring(0, existingLabel + SPRING_LABEL.length());
		}
		else {
			base = prefix + SPRING_LABEL;
		}

		// When the generated class name is for a FastClass, the source is
		// "org.springframework.cglib.reflect.FastClass".
		boolean isFastClass = (source != null && source.endsWith(".FastClass"));
		if (isFastClass && !prefix.contains(FAST_CLASS_SUFFIX)) {
			base += FAST_CLASS_SUFFIX;
		}

		int index = 0;
		String attempt = base + index;
		while (names.evaluate(attempt)) {
			attempt = base + index++;
		}
		return attempt;
	}

}

```

So to make the Spring plugin compatible with Spring framework 6.x, the name should be added in org.hotswap.agent.plugin.spring.getbean.EnhancerProxyCreater#isSupportedCglibProxy
```java
public static boolean isSupportedCglibProxy(Object bean) {
        if (bean == null) {
            return false;
        }
        String beanClassName = bean.getClass().getName();
        return beanClassName.contains("$$EnhancerBySpringCGLIB") || beanClassName.contains("$$EnhancerByCGLIB") || beanClassName.contains("$$SpringCGLIB");
    }
```

I added it in isSupportedCglibProxy and had a try, but it resulted in an error
```java
HOTSWAP AGENT: 18:52:40.626 ERROR (org.hotswap.agent.plugin.spring.getbean.EnhancerProxyCreater) - Creating a proxy failed
org.hotswap.agent.javassist.CannotCompileException: no inheritable constructor in org.springframework.cglib.core.SpringNamingPolicy
	at org.hotswap.agent.javassist.CtNewClass.inheritAllConstructors(CtNewClass.java:111)
	at org.hotswap.agent.javassist.CtNewClass.toBytecode(CtNewClass.java:69)
	at org.hotswap.agent.javassist.CtClass.toBytecode(CtClass.java:1525)
	at org.hotswap.agent.javassist.ClassPool.toClass(ClassPool.java:1233)
	at org.hotswap.agent.javassist.CtClass.toClass(CtClass.java:1398)
	at org.hotswap.agent.plugin.spring.getbean.EnhancerProxyCreater.buildNamingPolicyClass(EnhancerProxyCreater.java:275)
	at org.hotswap.agent.plugin.spring.getbean.EnhancerProxyCreater.getProxyCreationMethod(EnhancerProxyCreater.java:146)
	at org.hotswap.agent.plugin.spring.getbean.EnhancerProxyCreater.doCreate(EnhancerProxyCreater.java:122)
	at org.hotswap.agent.plugin.spring.getbean.EnhancerProxyCreater.create(EnhancerProxyCreater.java:104)
	at org.hotswap.agent.plugin.spring.getbean.EnhancerProxyCreater.createProxy(EnhancerProxyCreater.java:92)
	at org.hotswap.agent.plugin.spring.getbean.ProxyReplacer.register(ProxyReplacer.java:101)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBean(DefaultListableBeanFactory.java)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:975)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:971)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:625)
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:754)
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:456)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:335)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1363)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1352)
	at org.hotswapagent.springboot_demo.SpringbootDemoApplication.main(SpringbootDemoApplication.java:10)
```


The error appears to be caused by the private constructor of SpringNamingPolicy, which prevents us from creating any subclasses of SpringNamingPolicy, something we attempt to do in the method buildNamingPolicyClass.

```java
private SpringNamingPolicy() {
	}
```

```java
  private Class<?> buildNamingPolicyClass(String cglibPackage, ClassPool cp) throws CannotCompileException, NotFoundException {
        CtClass ct = cp.makeClass("HotswapAgentSpringNamingPolicy" + getClassSuffix(cglibPackage));
        String core = cglibPackage + "core.";
        String originalNamingPolicy = core + "SpringNamingPolicy";
        if (cp.find(originalNamingPolicy) == null)
            originalNamingPolicy = core + "DefaultNamingPolicy";
        ct.setSuperclass(cp.get(originalNamingPolicy));
        String rawBody =
                "public String getClassName(String prefix, String source, Object key, {0}Predicate names) {" +
                        "return super.getClassName(prefix + \"$HOTSWAPAGENT_\", source, key, names);" +
                "}";
        String body = rawBody.replaceAll("\\{0\\}", core);
        CtMethod m = CtNewMethod.make(body, ct);
        ct.addMethod(m);
        return ct.toClass(loader, pd);
```

