### PR TITLE
remove setCacheBeanMetadata to false, fix Spring @Order not work issue

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/SpringPlugin.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/SpringPlugin.java
@@ -249,7 +249,6 @@ public class SpringPlugin {
     @OnClassLoadEvent(classNameRegexp = "org.springframework.beans.factory.support.DefaultListableBeanFactory")
     public static void register(ClassLoader appClassLoader, CtClass clazz, ClassPool classPool) throws NotFoundException, CannotCompileException {
         StringBuilder src = new StringBuilder("{");
-        src.append("setCacheBeanMetadata(false);");
         // init a spring plugin with every appclassloader
         src.append(PluginManagerInvoker.buildInitializePlugin(SpringPlugin.class));
         src.append(PluginManagerInvoker.buildCallPluginMethod(SpringPlugin.class, "init",


### PR DESCRIPTION
metadata will be cleared after bean class change in SpringBeanReload invokeBeanFactoryPostProcessors(beanFactory);

in  PostProcessorRegistrationDelegate it wil clear beanFactory.clearMetadataCache();

Not sure why it fixed the issue, but I haven't noticed any side effects. It would be great if someone could help review it. remove the code also can improve the performance, my project start time from 11 second to 9 seconds.

@cvictory @edudant  @skybber  help review thanks.