### PR TITLE
Prevented initializing of abstract beans in SpringBeanReload::preInstantiateSingleton

### DIFF
--- a/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reload/SpringBeanReload.java
+++ b/plugin/hotswap-agent-spring-plugin/src/main/java/org/hotswap/agent/plugin/spring/reload/SpringBeanReload.java
@@ -527,7 +527,7 @@ public class SpringBeanReload {
                 LOGGER.debug("bean not found: " + beanName);
                 continue;
             }
-            if (beanDefinition.isSingleton()) {
+            if (!beanDefinition.isAbstract() && beanDefinition.isSingleton()) {
                 try {
                     beanFactory.getBean(beanName);
                 } catch (Exception e) {


### PR DESCRIPTION
I noticed that from time to time the plugin tries reloading abstract beans which causes a total mess in the console and in my specific case crashes everything so that I need to restart the server completely. 