### PR TITLE
Adapt to GlassFish 7

### DIFF
--- a/plugin/hotswap-agent-glassfish-plugin/src/main/java/org/hotswap/agent/plugin/glassfish/WebappClassLoaderTransformer.java
+++ b/plugin/hotswap-agent-glassfish-plugin/src/main/java/org/hotswap/agent/plugin/glassfish/WebappClassLoaderTransformer.java
@@ -35,12 +35,18 @@ public class WebappClassLoaderTransformer {
     public static void patchWebappClassLoader(ClassPool classPool,CtClass ctClass) throws CannotCompileException, NotFoundException {
         if (!webappClassLoaderPatched) {
             try {
+                String cacheFieldName = "resourceEntries";
+                try {
+                    ctClass.getDeclaredField(cacheFieldName);
+                } catch (NotFoundException e) {
+                    cacheFieldName = "resourceEntryCache";
+                }
                 // clear classloader cache
                 ctClass.getDeclaredMethod("getResource", new CtClass[]{classPool.get("java.lang.String")}).insertBefore(
-                        "resourceEntries.clear();"
+                        cacheFieldName + ".clear();"
                 );
                 ctClass.getDeclaredMethod("getResourceAsStream", new CtClass[]{classPool.get("java.lang.String")}).insertBefore(
-                        "resourceEntries.clear();"
+                        cacheFieldName + ".clear();"
                 );
                 webappClassLoaderPatched = true;
             } catch (NotFoundException e) {


### PR DESCRIPTION
Field "resourceEntries", [used by glassfish-plugin](https://github.com/HotswapProjects/HotswapAgent/blob/2df6bf6b2b37df378e25ae9c6b27bb3c469235f8/plugin/hotswap-agent-glassfish-plugin/src/main/java/org/hotswap/agent/plugin/glassfish/WebappClassLoaderTransformer.java#L40), [was replaced](https://github.com/eclipse-ee4j/glassfish/commit/256d73b4c5f1ebefc08044a7d7c1772792afa893#diff-0141ffd3d9718ae19012299c13f1c8db7fec76927fd5d82a2bfc8d227b69668dR188-L194) with resourceEntryCache in GlassFish 7 and higher.
In this PR plugin is adapted to this change.
Stay compatible with previous versions of GlassFish.