### PR TITLE
fix: Add null check for package name in VaadinPlugin

### DIFF
--- a/plugin/hotswap-agent-vaadin-plugin/src/main/java/org/hotswap/agent/plugin/vaadin/VaadinPlugin.java
+++ b/plugin/hotswap-agent-vaadin-plugin/src/main/java/org/hotswap/agent/plugin/vaadin/VaadinPlugin.java
@@ -247,7 +247,7 @@ public class VaadinPlugin {
         if (!isPluginReady(event + " for class " + className)) {
             return;
         }
-        if ((ctClass.getPackageName() != null) && !isWatchedPackage(ctClass.getPackageName())) {
+        if ((ctClass.getPackageName() == null) || !isWatchedPackage(ctClass.getPackageName())) {
             LOGGER.trace("Ignoring class {} because it is not in the watched-packages list", className);
             return;
         }


### PR DESCRIPTION
Fixes NullPointerException when inspecting classes that belong to no package, such as those generated on the fly by Jasper and loaded via net.sf.jasperreports.engine.util.CompiledClassesLoader.

Fixes #653 