### PR TITLE
Refactor structure of project and bump plugins - disable parallel mode

### DIFF
--- a/hotswap-agent-parent/pom.xml
+++ b/hotswap-agent-parent/pom.xml
@@ -155,6 +155,7 @@
                 <configuration>
                     <useSystemClassLoader>true</useSystemClassLoader>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
+                    <parallel>none</parallel>
                     <!--
                     <useSystemClassLoader>true</useSystemClassLoader>
                     <useManifestOnlyJar>false</useManifestOnlyJar>

--- a/plugin/hotswap-agent-mybatis-plugin/src/test/java/org/hotswap/agent/plugin/mybatis/AMyBatisPluginTest.java
+++ b/plugin/hotswap-agent-mybatis-plugin/src/test/java/org/hotswap/agent/plugin/mybatis/AMyBatisPluginTest.java
@@ -32,7 +32,7 @@ import java.nio.file.Files;
 
 import static org.junit.Assert.assertEquals;
 
-public class MyBatisPluginTest extends BaseTest {
+public class AMyBatisPluginTest extends BaseTest {
 
   private static SqlSessionFactory sqlSessionFactory;
 

--- a/plugin/hotswap-agent-proxy-plugin/pom.xml
+++ b/plugin/hotswap-agent-proxy-plugin/pom.xml
@@ -76,6 +76,7 @@
                         <configuration>
                             <forkCount>1</forkCount>
                             <reuseForks>false</reuseForks>
+                            <parallel>none</parallel>
                             <argLine>
                                 -XX:+AllowEnhancedClassRedefinition
                                 -XX:HotswapAgent=external


### PR DESCRIPTION
I've noticed that tests can randomly fails after update with build.
Disabling parallel mode in testing is solution.
Changed order of mybatis tests (now it's passing on linux)