### PR TITLE
Exclude ByteBuddy classloaders from plugin class patching

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/util/classloader/ClassLoaderDefineClassPatcher.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/util/classloader/ClassLoaderDefineClassPatcher.java
@@ -210,9 +210,12 @@ public class ClassLoaderDefineClassPatcher {
         // exclude synthetic classloader where it does not make any sense
 
         // sun.reflect.DelegatingClassLoader - created automatically by JVM to optimize reflection calls
+        // ByteArrayClassLoader - created by ByteBuddy for dynamic dispatchers (e.g. Mockito inline mocks)
         return classLoader != null &&
                 !classLoader.getClass().getName().equals("sun.reflect.DelegatingClassLoader") &&
-                !classLoader.getClass().getName().equals("jdk.internal.reflect.DelegatingClassLoader")
+                !classLoader.getClass().getName().equals("jdk.internal.reflect.DelegatingClassLoader") &&
+                !classLoader.getClass().getName().equals("net.bytebuddy.dynamic.loading.ByteArrayClassLoader") &&
+                !classLoader.getClass().getName().equals("net.bytebuddy.utility.dispatcher.JavaDispatcher$DynamicClassLoader")
                 ;
     }
 }


### PR DESCRIPTION
ClassLoaderDefineClassPatcher.isPatchAvailable() did not exclude ByteBuddy's synthetic classloaders (ByteArrayClassLoader and JavaDispatcher$DynamicClassLoader). When Mockito's inline mock maker uses ByteBuddy to retransform classes, HotswapAgent would patch all plugin classes (including inner classes like
VaadinPlugin$UpdateRoutesCommand) into ByteBuddy's classloaders.

This causes IllegalAccessError because the plugin's inner classes end up in a different classloader than the plugin class itself:

  "failed to access class VaadinPlugin$UpdateRoutesCommand from class
   VaadinPlugin (VaadinPlugin$UpdateRoutesCommand is in unnamed module
   of loader ByteArrayClassLoader; VaadinPlugin is in unnamed module
   of loader 'app')"

The fix adds ByteBuddy's ByteArrayClassLoader and
JavaDispatcher$DynamicClassLoader to the exclusion list, matching the existing exclusions for JDK's DelegatingClassLoader. These synthetic classloaders should never receive HotswapAgent plugin class definitions.

Fixes https://github.com/HotswapProjects/HotswapAgent/issues/671