### PR TITLE
AnonymousClassPatch: skip Spring CGLIB proxies

### DIFF
--- a/hotswap-agent-core/src/main/java/org/hotswap/agent/plugin/jvm/AnonymousClassPatchPlugin.java
+++ b/hotswap-agent-core/src/main/java/org/hotswap/agent/plugin/jvm/AnonymousClassPatchPlugin.java
@@ -94,6 +94,10 @@ public class AnonymousClassPatchPlugin {
     public static CtClass patchAnonymousClass(ClassLoader classLoader, ClassPool classPool, String className, Class original)
             throws IOException, NotFoundException, CannotCompileException {
 
+        // skip synthetic proxy/lambda classes (e.g. Foo$$SpringCGLIB$$0), not source anonymous classes
+        if (isSyntheticClass(className))
+            return null;
+
         String javaClass = className.replaceAll("/", ".");
         String mainClass = javaClass.replaceAll("\\$\\d+$", "");
 
@@ -131,6 +135,11 @@ public class AnonymousClassPatchPlugin {
             // replaced with a new version. Automatic update of old instances containing references to obsolete
             // class is not supported yet.");
         }
+    }
+
+    // CGLIB/ByteBuddy proxies and lambdas carry a double $$; source anonymous/local classes never do.
+    static boolean isSyntheticClass(String className) {
+        return className != null && className.contains("$$");
     }
 
     private static boolean isHotswapAgentSyntheticClass(String compatibleName) {
@@ -176,6 +185,9 @@ public class AnonymousClassPatchPlugin {
     @OnClassLoadEvent(classNameRegexp = ".*", events = LoadEvent.REDEFINE)
     public static byte[] patchMainClass(String className, ClassPool classPool, CtClass ctClass,
                                         ClassLoader classLoader, ProtectionDomain protectionDomain) throws IOException, CannotCompileException, NotFoundException {
+        if (isSyntheticClass(className))
+            return null;
+
         String javaClassName = className.replaceAll("/", ".");
 
         // check if has anonymous classes

--- a/hotswap-agent-core/src/test/java/org/hotswap/agent/plugin/jvm/AnonymousClassPatchPluginTest.java
+++ b/hotswap-agent-core/src/test/java/org/hotswap/agent/plugin/jvm/AnonymousClassPatchPluginTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2026 the HotswapAgent authors.
+ *
+ * This file is part of HotswapAgent.
+ *
+ * HotswapAgent is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * HotswapAgent is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with HotswapAgent. If not, see http://www.gnu.org/licenses/.
+ */
+package org.hotswap.agent.plugin.jvm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+public class AnonymousClassPatchPluginTest {
+
+    private static final Pattern ANONYMOUS_EVENT = Pattern.compile(".*\\$\\d+");
+
+    @Test
+    public void springCglibProxyNameMatchesTheAnonymousEventFilter() {
+        assertTrue(ANONYMOUS_EVENT.matcher("com.example.AppConfig$$SpringCGLIB$$0").matches());
+    }
+
+    @Test
+    public void springCglibProxyDerivesABogusMainClassWithoutTheGuard() {
+        String cglib = "com.example.AppConfig$$SpringCGLIB$$0";
+        assertEquals("com.example.AppConfig$$SpringCGLIB$", cglib.replaceAll("\\$\\d+$", ""));
+        assertTrue(AnonymousClassPatchPlugin.isSyntheticClass(cglib));
+    }
+
+    @Test
+    public void treatsProxyAndLambdaClassesAsSynthetic() {
+        assertTrue(AnonymousClassPatchPlugin.isSyntheticClass("com.example.AppConfig$$SpringCGLIB$$0"));
+        assertTrue(AnonymousClassPatchPlugin.isSyntheticClass("com/example/AppConfig$$SpringCGLIB$$0"));
+        assertTrue(AnonymousClassPatchPlugin.isSyntheticClass("com.example.AppConfig$$EnhancerBySpringCGLIB$$1a2b3c4d"));
+        assertTrue(AnonymousClassPatchPlugin.isSyntheticClass("com.example.AppConfig$$FastClassBySpringCGLIB$$e9dcbb28"));
+        assertTrue(AnonymousClassPatchPlugin.isSyntheticClass("com.example.Foo$$Lambda$1"));
+    }
+
+    @Test
+    public void keepsRealAnonymousAndLocalClasses() {
+        assertFalse(AnonymousClassPatchPlugin.isSyntheticClass("com.example.Foo$1"));
+        assertFalse(AnonymousClassPatchPlugin.isSyntheticClass("com/example/Foo$1"));
+        assertFalse(AnonymousClassPatchPlugin.isSyntheticClass("com.example.Foo$Bar$2"));
+        assertFalse(AnonymousClassPatchPlugin.isSyntheticClass("com.example.Foo$1Local"));
+        assertFalse(AnonymousClassPatchPlugin.isSyntheticClass("com.example.Foo"));
+    }
+
+    @Test
+    public void nullClassNameIsNotSynthetic() {
+        assertFalse(AnonymousClassPatchPlugin.isSyntheticClass(null));
+    }
+}


### PR DESCRIPTION
Since Spring 6.0, CGLIB proxies (of @Configuration and AOP beans) are
named e.g. AppConfig$$SpringCGLIB$$0. The trailing integer matches the
plugin's ".*\$\d+" redefinition event, so it treats the proxy as an
anonymous class, strips "$0" to a bogus enclosing class, and throws
resolving its anonymous-class state -- an InvocationTargetException on
every @Configuration reload. The known workaround,
disabledPlugins=AnonymousClassPatch, also loses real anonymous-class
hot-swap.

Spring 5.x named proxies $$EnhancerBySpringCGLIB$$<hex>, which never
matched; the integer suffix arrived with SpringNamingPolicy in
spring-projects/spring-framework@b31a15851e7a (6.0).

Fix: skip synthetic classes (name contains "$$") in patchAnonymousClass
and patchMainClass. A source anonymous/local class never does, so real
patching is unaffected. Adds AnonymousClassPatchPluginTest.
